### PR TITLE
Removes keycloak service type LoadBalancer.

### DIFF
--- a/folio-test/infrastructure/keycloak.yaml
+++ b/folio-test/infrastructure/keycloak.yaml
@@ -108,7 +108,6 @@ containerSecurityContext:
 networkPolicy:
   enabled: false
 service:
-  type: "LoadBalancer"
   ports:
     http: 8080
     https: 8443


### PR DESCRIPTION
The default service type in the chart is ClusterIP. I'm not entirely sure why it was changed to "LoadBalancer" in [this commit](https://github.com/sul-dlss/folio-eureka/commit/2bf05fc12d5bba30d2208b55c28a6dcdce162287#diff-ff21f3c1377af41c26b8587fcc9b8683312012125dce7f824a1b179ab0d70626). Once I made that change, the service was no longer pending. However, the ports are only 8080 and not also 8443 for https, so maybe that is why it was "LoadBalancer"? I can login to keycloak-folio-test with these settings (service type ClusterIP).