### PR TITLE
Adds existing secrets for Kafka kraft cluster and sasl user.

### DIFF
--- a/folio-stage/infrastructure/kafka.yaml
+++ b/folio-stage/infrastructure/kafka.yaml
@@ -44,6 +44,10 @@ extraConfig: |
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true
 
+kraft:
+  existingClusterIdSecret: kafka-credentials
+sasl:
+  existingSecret: kafka-credentials
 listeners:
   client:
     protocol: PLAINTEXT

--- a/folio-test/infrastructure/kafka.yaml
+++ b/folio-test/infrastructure/kafka.yaml
@@ -44,6 +44,10 @@ extraConfig: |
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true
 
+kraft:
+  existingClusterIdSecret: kafka-credentials
+sasl:
+  existingSecret: kafka-credentials
 listeners:
   client:
     protocol: PLAINTEXT


### PR DESCRIPTION
I ran helm template with this override file and it did not create new secrets for kafka-folio-test-kraft-cluster-id or kafka-folio-test-user-passwords. I think this will allow ArgoCD to sync the app.