### PR TITLE
Use create_applications script to deploy modules with prod replicas

### DIFF
--- a/create_applications.py
+++ b/create_applications.py
@@ -13,9 +13,10 @@ parser = argparse.ArgumentParser(
 parser.add_argument("filename")
 parser.add_argument("-m", "--modules", help="a list of modules to install, each with -m flag", nargs="+", action="extend")
 parser.add_argument("-n", "--namespace", required=True, help="the Kubernetes namespace for the applications")
+parser.add_argument("-p", "--prod_replicasets", action="store_true", default=False, help="use production-level replicaset counts, else replicaCount=1")
 parser.add_argument("-r", "--helm_repo", default="folio-helm-v2-dlss", help="the Helm repository to use for the applications (folio-helm-v2-dlss by default)")
 parser.add_argument("-v", "--values_branch", default="main", help="the branch in the values repository to use for the applications (main by default)")
-parser.add_argument("-x", "--execute", required=True, default="dry-run", choices=["apply", "dry-run"], help="whether to apply the applications to ArgoCD or just do a dry-run (dry-run by default)")
+parser.add_argument("-x", "--execute", required=False, default="dry-run", choices=["apply", "dry-run"], help="whether to apply the applications to ArgoCD or just do a dry-run (dry-run by default)")
 
 args = parser.parse_args()
 
@@ -89,6 +90,9 @@ for module in modules:
     else:
         values_files.append(f"$values/{args.namespace}/common/probes.yaml")
 
+    if args.prod_replicasets and Path(f"{args.namespace}/modules/{module_name}/replicas.yaml").exists():
+        values_files.append(f"$values/{args.namespace}/modules/{module_name}/replicas.yaml")
+
     if Path(f"{args.namespace}/modules/{module_name}/service.yaml").exists():
         values_files.append(f"$values/{args.namespace}/modules/{module_name}/service.yaml")
     
@@ -97,7 +101,6 @@ for module in modules:
     
     if Path(f"{args.namespace}/modules/{module_name}/extra_env.yaml").exists():
         values_files.append(f"$values/{args.namespace}/modules/{module_name}/extra_env.yaml")
-
     
     chart_version = os.popen(f"helm show chart {args.helm_repo}/{module_name} | grep \"^version\" | awk '{{print $2}}'").read().strip()
     

--- a/create_module_values.py
+++ b/create_module_values.py
@@ -6,14 +6,13 @@ import yaml
 from pathlib import Path
 
 parser = argparse.ArgumentParser(
-                    prog="CreateModuleValues",
-                    description="Create FOLIO Eureka module values using application descriptors",
-                    epilog="-------")
+                    prog='CreateModuleValues',
+                    description='Create FOLIO Eureka module values using application descriptors',
+                    epilog='-------')
 
-parser.add_argument("filename")
-parser.add_argument("-m", "--modules", help="a list of modules to install, each with -m flag", nargs="+", action="extend")
-parser.add_argument("-n", "--namespace", required=True, help="the Kubernetes namespace for the applications")
-parser.add_argument("-p", "--prod_replicasets", action="store_true", help="use production-level replicaset counts, else replicaCount=1")
+parser.add_argument('filename')
+parser.add_argument('-m', '--modules', help='a list of modules to install, each with -m flag', nargs="+", action='extend')
+parser.add_argument('-n', '--namespace', required=True, help='the Kubernetes namespace for the applications')
 
 args = parser.parse_args()
 
@@ -30,34 +29,11 @@ S3_MODULES = [
     "mod-users",
 ]
 
-ONE_REPLICASET = [
-    "mod-data-export",
-    "mod-data-export-spring",
-    "mod-data-export-worker",
-    "mod-data-import",
-    "mod-erm-usage-harvester",
-    "mod-quick-marc",
-]
-
-THREE_REPLICASET = [
-    "mod-circulation",
-    "mod-circulation-storage",
-    "mod-configuration",
-    "mod-finance",
-    "mod-finance-storage",
-    "mod-inventory",
-    "mod-inventory-storage",
-    "mod-orders",
-    "mod-orders-storage",
-    "mod-users",
-    "mod-users-bl",
-]
-
-def base_override(name, version, prod_rs):
+def base_override(name, version):
     data = {
         "image": {"repository": f"folioorg/{name}", "tag": f"{version}"},
         "podSecurityContext": {"fsGroup": 2000},
-        "securityContext":{"capabilities": {"drop": ["ALL"]},
+        "securityContext":{"capabilities": {"drop": ['ALL']},
             "runAsNonRoot": True,
             "runAsUser": 1000,
             "allowPrivilegeEscalation": False
@@ -75,45 +51,37 @@ def base_override(name, version, prod_rs):
     }
     
     if name in S3_MODULES:
-        data["integrations"]["s3"] = {"enabled": True, "existingSecret": "s3-credentials"}
-    if not name.startswith("mod-pubsub"):
-        data["eureka"]["extraEnvVars"] = [
+        data['integrations']['s3'] = {"enabled": True, "existingSecret": "s3-credentials"}
+    if not name.startswith('mod-pubsub'):
+        data['eureka']['extraEnvVars'] = [
             {"name": "FOLIO_SYSTEM_USER_ENABLED", "value": "false"},
             {"name": "SYSTEM_USER_CREATED", "value": "false"},
             {"name": "SYSTEM_USER_ENABLED", "value": "false"},
         ]
-    if name.startswith("mod-reporting"):
-        del data["securityContext"]["runAsUser"]
-    if name.startswith("edge-"):
-        del data["integrations"]["db"]
-        del data["integrations"]["kafka"]
-        data["integrations"]["eureka-edge"] = {"enabled": True, "existingSecret": "eureka-edge"}
-
-    if prod_rs:
-        data["replicaCount"] = 2
-        if name in ONE_REPLICASET:
-            data["replicaCount"] = 1
-        if name in THREE_REPLICASET:
-            data["replicaCount"] = 3
-
+    if name.startswith('mod-reporting'):
+        del data['securityContext']['runAsUser']
+    if name.startswith('edge-'):
+        del data['integrations']['db']
+        del data['integrations']['kafka']
+        data['integrations']['eureka-edge'] = {"enabled": True, "existingSecret": "eureka-edge"}
+    
     return yaml.dump(data)
 
 
-with open(args.filename, "r") as file:
+with open(args.filename, 'r') as file:
     data = json.load(file)
 
-modules = data["modules"]
+modules = data['modules']
 
 if args.modules:
-    modules = [obj for obj in data["modules"] if obj["name"] in args.modules]
-
+    modules = [obj for obj in data['modules'] if obj['name'] in args.modules]
+        
 for module in modules:
-    name = module["name"]
-    version = module["version"]
+    name = module['name']
+    version = module['version']
     dir = Path(f"{args.namespace}/modules/{name}")
     dir.mkdir(parents=True, exist_ok=True)
-    prod_rs = args.prod_replicasets
     
     filename = f"{dir}/overrides.yaml"
-    with open(filename, "w") as file:
-        file.write(base_override(name, version, prod_rs))
+    with open(filename, 'w') as file:
+        file.write(base_override(name, version))

--- a/folio-dev/modules/edge-connexion/application.yaml
+++ b/folio-dev/modules/edge-connexion/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/edge-connexion/service.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.1.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/edge-ncip/application.yaml
+++ b/folio-dev/modules/edge-ncip/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/edge-ncip/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.9.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/edge-sip2/application.yaml
+++ b/folio-dev/modules/edge-sip2/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/edge-sip2/probes.yaml
       - $values/folio-dev/modules/edge-sip2/service.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mgr-applications/application.yaml
+++ b/folio-dev/modules/mgr-applications/application.yaml
@@ -21,4 +21,4 @@ spec:
     targetRevision: 0.0.16
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
-    targetRevision: argo-cd
+    targetRevision: main

--- a/folio-dev/modules/mgr-tenant-entitlements/application.yaml
+++ b/folio-dev/modules/mgr-tenant-entitlements/application.yaml
@@ -21,4 +21,4 @@ spec:
     targetRevision: 0.0.16
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
-    targetRevision: argo-cd
+    targetRevision: main

--- a/folio-dev/modules/mgr-tenants/application.yaml
+++ b/folio-dev/modules/mgr-tenants/application.yaml
@@ -21,4 +21,4 @@ spec:
     targetRevision: 0.0.16
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
-    targetRevision: argo-cd
+    targetRevision: main

--- a/folio-dev/modules/mod-agreements/application.yaml
+++ b/folio-dev/modules/mod-agreements/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-agreements/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-agreements/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.0.55
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-audit/application.yaml
+++ b/folio-dev/modules/mod-audit/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-audit/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.8.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-batch-print/application.yaml
+++ b/folio-dev/modules/mod-batch-print/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-batch-print/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-calendar/application.yaml
+++ b/folio-dev/modules/mod-calendar/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-calendar/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-circulation-storage/application.yaml
+++ b/folio-dev/modules/mod-circulation-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-circulation-storage/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 17.2.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-circulation/application.yaml
+++ b/folio-dev/modules/mod-circulation/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-circulation/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-circulation/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 24.1.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-configuration/application.yaml
+++ b/folio-dev/modules/mod-configuration/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-configuration/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.9.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-copycat/application.yaml
+++ b/folio-dev/modules/mod-copycat/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-copycat/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-courses/application.yaml
+++ b/folio-dev/modules/mod-courses/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-courses/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.5.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-data-export-spring/application.yaml
+++ b/folio-dev/modules/mod-data-export-spring/application.yaml
@@ -22,7 +22,7 @@ spec:
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-data-export-spring/java_opts.yaml
       - $values/folio-dev/modules/mod-data-export-spring/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-data-export-worker/application.yaml
+++ b/folio-dev/modules/mod-data-export-worker/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-data-export-worker/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.2.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-data-export/application.yaml
+++ b/folio-dev/modules/mod-data-export/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-data-export/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.9.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-data-import/application.yaml
+++ b/folio-dev/modules/mod-data-import/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-data-import/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-di-converter-storage/application.yaml
+++ b/folio-dev/modules/mod-di-converter-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-di-converter-storage/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.2.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-ebsconet/application.yaml
+++ b/folio-dev/modules/mod-ebsconet/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/common/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-ebsconet/replicas.yaml
+++ b/folio-dev/modules/mod-ebsconet/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-dev/modules/mod-email/application.yaml
+++ b/folio-dev/modules/mod-email/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-email/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.16.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-entities-links/application.yaml
+++ b/folio-dev/modules/mod-entities-links/application.yaml
@@ -22,7 +22,7 @@ spec:
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-entities-links/java_opts.yaml
       - $values/folio-dev/modules/mod-entities-links/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-event-config/application.yaml
+++ b/folio-dev/modules/mod-event-config/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-event-config/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.6.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-feesfines/application.yaml
+++ b/folio-dev/modules/mod-feesfines/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-feesfines/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 19.0.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-finance-storage/application.yaml
+++ b/folio-dev/modules/mod-finance-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-finance-storage/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 8.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-finance/application.yaml
+++ b/folio-dev/modules/mod-finance/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-finance/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.8.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-gobi/application.yaml
+++ b/folio-dev/modules/mod-gobi/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-gobi/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.7.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-gobi/replicas.yaml
+++ b/folio-dev/modules/mod-gobi/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-dev/modules/mod-graphql/application.yaml
+++ b/folio-dev/modules/mod-graphql/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-graphql/probes.yaml
       - $values/folio-dev/modules/mod-graphql/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.12.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-inventory-storage/application.yaml
+++ b/folio-dev/modules/mod-inventory-storage/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-inventory-storage/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 27.1.42
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-inventory-storage/extra_env.yaml
+++ b/folio-dev/modules/mod-inventory-storage/extra_env.yaml
@@ -1,8 +1,6 @@
 # mod-inventory-storage requires REPLICATION_FACTOR to be set as env variable because it creates necessary topics on its own
 # and it won’t be overridden by the kafka configured setting.
 # In addition to setting the number of pod replicas, REPLICATION_FACTOR env is set using the replicaCount setting
-replicaCount: 3
-
 # Include the extraEnvVars from the chart, and then add our REPLICATION_FACTOR.
 extraEnvVars: |
   - name: DB_EXPLAIN_QUERY_THRESHOLD

--- a/folio-dev/modules/mod-inventory-update/application.yaml
+++ b/folio-dev/modules/mod-inventory-update/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/common/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-inventory-update/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.2.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-inventory-update/replicas.yaml
+++ b/folio-dev/modules/mod-inventory-update/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-dev/modules/mod-inventory/application.yaml
+++ b/folio-dev/modules/mod-inventory/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-inventory/probes.yaml
       - $values/folio-dev/modules/mod-inventory/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 20.2.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-invoice-storage/application.yaml
+++ b/folio-dev/modules/mod-invoice-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-invoice-storage/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.7.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-invoice/application.yaml
+++ b/folio-dev/modules/mod-invoice/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-invoice/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.8.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-kb-ebsco-java/application.yaml
+++ b/folio-dev/modules/mod-kb-ebsco-java/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/common/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.0.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-kb-ebsco-java/replicas.yaml
+++ b/folio-dev/modules/mod-kb-ebsco-java/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-dev/modules/mod-licenses/application.yaml
+++ b/folio-dev/modules/mod-licenses/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-licenses/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-licenses/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-login-keycloak/application.yaml
+++ b/folio-dev/modules/mod-login-keycloak/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/modules/mod-login-keycloak/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-login-keycloak/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-ncip/application.yaml
+++ b/folio-dev/modules/mod-ncip/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-ncip/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.0.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-notes/application.yaml
+++ b/folio-dev/modules/mod-notes/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-notes/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-notify/application.yaml
+++ b/folio-dev/modules/mod-notify/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-notify/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-okapi-facade/application.yaml
+++ b/folio-dev/modules/mod-okapi-facade/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/common/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.27
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-orders-storage/application.yaml
+++ b/folio-dev/modules/mod-orders-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-orders-storage/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 13.6.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-orders/application.yaml
+++ b/folio-dev/modules/mod-orders/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-orders/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 12.7.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-organizations-storage/application.yaml
+++ b/folio-dev/modules/mod-organizations-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-organizations-storage/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.6.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-organizations/application.yaml
+++ b/folio-dev/modules/mod-organizations/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-organizations/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.8.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-password-validator/application.yaml
+++ b/folio-dev/modules/mod-password-validator/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-password-validator/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-patron-blocks/application.yaml
+++ b/folio-dev/modules/mod-patron-blocks/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-patron-blocks/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.9.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-patron/application.yaml
+++ b/folio-dev/modules/mod-patron/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-patron/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.0.47
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-permissions/application.yaml
+++ b/folio-dev/modules/mod-permissions/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-permissions/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.4.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-pubsub/application.yaml
+++ b/folio-dev/modules/mod-pubsub/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-pubsub/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-quick-marc/application.yaml
+++ b/folio-dev/modules/mod-quick-marc/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-quick-marc/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-record-specifications/application.yaml
+++ b/folio-dev/modules/mod-record-specifications/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/common/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-roles-keycloak/application.yaml
+++ b/folio-dev/modules/mod-roles-keycloak/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/modules/mod-roles-keycloak/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-roles-keycloak/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-rtac/application.yaml
+++ b/folio-dev/modules/mod-rtac/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-rtac/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-scheduler/application.yaml
+++ b/folio-dev/modules/mod-scheduler/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-scheduler/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-search/application.yaml
+++ b/folio-dev/modules/mod-search/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-search/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-sender/application.yaml
+++ b/folio-dev/modules/mod-sender/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-sender/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-sender/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.11.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-serials-management/application.yaml
+++ b/folio-dev/modules/mod-serials-management/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-serials-management/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-serials-management/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-service-interaction/application.yaml
+++ b/folio-dev/modules/mod-service-interaction/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-service-interaction/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/modules/mod-service-interaction/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-settings/application.yaml
+++ b/folio-dev/modules/mod-settings/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-settings/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-source-record-manager/application.yaml
+++ b/folio-dev/modules/mod-source-record-manager/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-source-record-manager/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.8.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-source-record-storage/application.yaml
+++ b/folio-dev/modules/mod-source-record-storage/application.yaml
@@ -22,7 +22,7 @@ spec:
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-source-record-storage/java_opts.yaml
       - $values/folio-dev/modules/mod-source-record-storage/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.8.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-tags/application.yaml
+++ b/folio-dev/modules/mod-tags/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-tags/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-template-engine/application.yaml
+++ b/folio-dev/modules/mod-template-engine/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/common/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.19.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-user-import/application.yaml
+++ b/folio-dev/modules/mod-user-import/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-user-import/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.8.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-users-bl/application.yaml
+++ b/folio-dev/modules/mod-users-bl/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-dev/modules/mod-users-bl/resources.yaml
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 7.6.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-users-keycloak/application.yaml
+++ b/folio-dev/modules/mod-users-keycloak/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/modules/mod-users-keycloak/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-users-keycloak/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-dev/modules/mod-users/application.yaml
+++ b/folio-dev/modules/mod-users/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-dev/common/sidecar.yaml
       - $values/folio-dev/common/probes.yaml
       - $values/folio-dev/modules/mod-users/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 19.3.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/edge-connexion/application.yaml
+++ b/folio-stage/modules/edge-connexion/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.1.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/edge-ncip/application.yaml
+++ b/folio-stage/modules/edge-ncip/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.9.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/edge-sip2/application.yaml
+++ b/folio-stage/modules/edge-sip2/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-agreements/application.yaml
+++ b/folio-stage/modules/mod-agreements/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-agreements/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-agreements/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.0.55
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-audit/application.yaml
+++ b/folio-stage/modules/mod-audit/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-audit/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.8.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-batch-print/application.yaml
+++ b/folio-stage/modules/mod-batch-print/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-bulk-operations/application.yaml
+++ b/folio-stage/modules/mod-bulk-operations/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-bulk-operations/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.2.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-calendar/application.yaml
+++ b/folio-stage/modules/mod-calendar/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-calendar/java_opts.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-circulation-bff/application.yaml
+++ b/folio-stage/modules/mod-circulation-bff/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.40
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-circulation-storage/application.yaml
+++ b/folio-stage/modules/mod-circulation-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-circulation-storage/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 17.2.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-circulation/application.yaml
+++ b/folio-stage/modules/mod-circulation/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-circulation/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-circulation/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 24.1.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-configuration/application.yaml
+++ b/folio-stage/modules/mod-configuration/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-configuration/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.9.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-copycat/application.yaml
+++ b/folio-stage/modules/mod-copycat/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-copycat/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-courses/application.yaml
+++ b/folio-stage/modules/mod-courses/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-courses/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.5.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-data-export-spring/application.yaml
+++ b/folio-stage/modules/mod-data-export-spring/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-data-export-spring/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-data-export-worker/application.yaml
+++ b/folio-stage/modules/mod-data-export-worker/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-data-export-worker/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.2.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-data-export/application.yaml
+++ b/folio-stage/modules/mod-data-export/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-data-export/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.9.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-data-import/application.yaml
+++ b/folio-stage/modules/mod-data-import/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-data-import/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-di-converter-storage/application.yaml
+++ b/folio-stage/modules/mod-di-converter-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-di-converter-storage/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.2.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-ebsconet/application.yaml
+++ b/folio-stage/modules/mod-ebsconet/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-ebsconet/replicas.yaml
+++ b/folio-stage/modules/mod-ebsconet/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-stage/modules/mod-email/application.yaml
+++ b/folio-stage/modules/mod-email/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-email/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.16.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-entities-links/application.yaml
+++ b/folio-stage/modules/mod-entities-links/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-entities-links/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-event-config/application.yaml
+++ b/folio-stage/modules/mod-event-config/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-event-config/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.6.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-feesfines/application.yaml
+++ b/folio-stage/modules/mod-feesfines/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-feesfines/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 19.0.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-finance-storage/application.yaml
+++ b/folio-stage/modules/mod-finance-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-finance-storage/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 8.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-finance/application.yaml
+++ b/folio-stage/modules/mod-finance/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-finance/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.8.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-fqm-manager/application.yaml
+++ b/folio-stage/modules/mod-fqm-manager/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-fqm-manager/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.1.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-gobi/application.yaml
+++ b/folio-stage/modules/mod-gobi/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-gobi/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.7.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-gobi/replicas.yaml
+++ b/folio-stage/modules/mod-gobi/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-stage/modules/mod-graphql/application.yaml
+++ b/folio-stage/modules/mod-graphql/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-graphql/probes.yaml
       - $values/folio-stage/modules/mod-graphql/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.12.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-inventory-storage/application.yaml
+++ b/folio-stage/modules/mod-inventory-storage/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-inventory-storage/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 27.1.42
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-inventory-update/application.yaml
+++ b/folio-stage/modules/mod-inventory-update/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-inventory-update/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.2.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-inventory-update/replicas.yaml
+++ b/folio-stage/modules/mod-inventory-update/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-stage/modules/mod-inventory/application.yaml
+++ b/folio-stage/modules/mod-inventory/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-inventory/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-inventory/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 20.2.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-invoice-storage/application.yaml
+++ b/folio-stage/modules/mod-invoice-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-invoice-storage/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.7.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-invoice/application.yaml
+++ b/folio-stage/modules/mod-invoice/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-invoice/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.8.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-kb-ebsco-java/application.yaml
+++ b/folio-stage/modules/mod-kb-ebsco-java/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.0.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-kb-ebsco-java/replicas.yaml
+++ b/folio-stage/modules/mod-kb-ebsco-java/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-stage/modules/mod-licenses/application.yaml
+++ b/folio-stage/modules/mod-licenses/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-licenses/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-licenses/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-lists/application.yaml
+++ b/folio-stage/modules/mod-lists/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-lists/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.1.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-login-keycloak/application.yaml
+++ b/folio-stage/modules/mod-login-keycloak/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-login-keycloak/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-ncip/application.yaml
+++ b/folio-stage/modules/mod-ncip/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-ncip/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.0.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-notes/application.yaml
+++ b/folio-stage/modules/mod-notes/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-notes/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-notify/application.yaml
+++ b/folio-stage/modules/mod-notify/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-notify/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-oai-pmh/application.yaml
+++ b/folio-stage/modules/mod-oai-pmh/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-oai-pmh/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.0.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-okapi-facade/application.yaml
+++ b/folio-stage/modules/mod-okapi-facade/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.27
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-orders-storage/application.yaml
+++ b/folio-stage/modules/mod-orders-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-orders-storage/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 13.6.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-orders/application.yaml
+++ b/folio-stage/modules/mod-orders/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-orders/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 12.7.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-organizations-storage/application.yaml
+++ b/folio-stage/modules/mod-organizations-storage/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-organizations-storage/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.6.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-organizations/application.yaml
+++ b/folio-stage/modules/mod-organizations/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-organizations/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.8.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-password-validator/application.yaml
+++ b/folio-stage/modules/mod-password-validator/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-password-validator/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-patron-blocks/application.yaml
+++ b/folio-stage/modules/mod-patron-blocks/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-patron-blocks/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.9.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-patron/application.yaml
+++ b/folio-stage/modules/mod-patron/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-patron/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.0.47
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-permissions/application.yaml
+++ b/folio-stage/modules/mod-permissions/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-permissions/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.4.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-pubsub/application.yaml
+++ b/folio-stage/modules/mod-pubsub/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-pubsub/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-quick-marc/application.yaml
+++ b/folio-stage/modules/mod-quick-marc/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-quick-marc/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-record-specifications/application.yaml
+++ b/folio-stage/modules/mod-record-specifications/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-roles-keycloak/application.yaml
+++ b/folio-stage/modules/mod-roles-keycloak/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-roles-keycloak/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-rtac/application.yaml
+++ b/folio-stage/modules/mod-rtac/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-rtac/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.5.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-scheduler/application.yaml
+++ b/folio-stage/modules/mod-scheduler/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-scheduler/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-search/application.yaml
+++ b/folio-stage/modules/mod-search/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-search/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-sender/application.yaml
+++ b/folio-stage/modules/mod-sender/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-sender/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-sender/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.11.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-serials-management/application.yaml
+++ b/folio-stage/modules/mod-serials-management/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-serials-management/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-serials-management/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-service-interaction/application.yaml
+++ b/folio-stage/modules/mod-service-interaction/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-service-interaction/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/modules/mod-service-interaction/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-settings/application.yaml
+++ b/folio-stage/modules/mod-settings/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-settings/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.50
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-source-record-manager/application.yaml
+++ b/folio-stage/modules/mod-source-record-manager/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-source-record-manager/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.8.43
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-source-record-storage/application.yaml
+++ b/folio-stage/modules/mod-source-record-storage/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-source-record-storage/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.8.44
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-tags/application.yaml
+++ b/folio-stage/modules/mod-tags/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-tags/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-template-engine/application.yaml
+++ b/folio-stage/modules/mod-template-engine/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/common/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.19.49
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-user-import/application.yaml
+++ b/folio-stage/modules/mod-user-import/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-user-import/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.8.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-users-bl/application.yaml
+++ b/folio-stage/modules/mod-users-bl/application.yaml
@@ -20,7 +20,7 @@ spec:
       - $values/folio-stage/modules/mod-users-bl/resources.yaml
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 7.6.48
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-users-keycloak/application.yaml
+++ b/folio-stage/modules/mod-users-keycloak/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-users-keycloak/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-stage/modules/mod-users/application.yaml
+++ b/folio-stage/modules/mod-users/application.yaml
@@ -21,7 +21,7 @@ spec:
       - $values/folio-stage/common/sidecar.yaml
       - $values/folio-stage/common/probes.yaml
       - $values/folio-stage/modules/mod-users/extra_env.yaml
-    repoURL: https://sul-dlss.github.io/folio-helm-v2/
+    repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 19.3.41
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka

--- a/folio-test/modules/mod-agreements/application.yaml
+++ b/folio-test/modules/mod-agreements/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-agreements/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-agreements/probes.yaml
+      - $values/folio-test/modules/mod-agreements/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.0.55
   - ref: values

--- a/folio-test/modules/mod-agreements/overrides.yaml
+++ b/folio-test/modules/mod-agreements/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-agreements/replicas.yaml
+++ b/folio-test/modules/mod-agreements/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-audit/application.yaml
+++ b/folio-test/modules/mod-audit/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-audit/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-audit/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.8.50
   - ref: values

--- a/folio-test/modules/mod-audit/overrides.yaml
+++ b/folio-test/modules/mod-audit/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-audit/replicas.yaml
+++ b/folio-test/modules/mod-audit/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-batch-print/application.yaml
+++ b/folio-test/modules/mod-batch-print/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-batch-print/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values

--- a/folio-test/modules/mod-batch-print/overrides.yaml
+++ b/folio-test/modules/mod-batch-print/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-batch-print/replicas.yaml
+++ b/folio-test/modules/mod-batch-print/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-bulk-operations/application.yaml
+++ b/folio-test/modules/mod-bulk-operations/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-bulk-operations/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-bulk-operations/replicas.yaml
       - $values/folio-test/modules/mod-bulk-operations/java_opts.yaml
       - $values/folio-test/modules/mod-bulk-operations/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2

--- a/folio-test/modules/mod-bulk-operations/overrides.yaml
+++ b/folio-test/modules/mod-bulk-operations/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-bulk-operations/replicas.yaml
+++ b/folio-test/modules/mod-bulk-operations/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-calendar/application.yaml
+++ b/folio-test/modules/mod-calendar/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-calendar/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-calendar/replicas.yaml
       - $values/folio-test/modules/mod-calendar/java_opts.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.5.48

--- a/folio-test/modules/mod-calendar/overrides.yaml
+++ b/folio-test/modules/mod-calendar/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-calendar/replicas.yaml
+++ b/folio-test/modules/mod-calendar/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-circulation-storage/application.yaml
+++ b/folio-test/modules/mod-circulation-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-circulation-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-circulation-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 17.2.43
   - ref: values

--- a/folio-test/modules/mod-circulation-storage/overrides.yaml
+++ b/folio-test/modules/mod-circulation-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-circulation-storage/replicas.yaml
+++ b/folio-test/modules/mod-circulation-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-circulation/application.yaml
+++ b/folio-test/modules/mod-circulation/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-circulation/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-circulation/probes.yaml
+      - $values/folio-test/modules/mod-circulation/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 24.1.43
   - ref: values

--- a/folio-test/modules/mod-circulation/overrides.yaml
+++ b/folio-test/modules/mod-circulation/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-circulation/replicas.yaml
+++ b/folio-test/modules/mod-circulation/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-configuration/application.yaml
+++ b/folio-test/modules/mod-configuration/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-configuration/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-configuration/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.9.50
   - ref: values

--- a/folio-test/modules/mod-configuration/overrides.yaml
+++ b/folio-test/modules/mod-configuration/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-configuration/replicas.yaml
+++ b/folio-test/modules/mod-configuration/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-copycat/application.yaml
+++ b/folio-test/modules/mod-copycat/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-copycat/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-copycat/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.5.48
   - ref: values

--- a/folio-test/modules/mod-copycat/overrides.yaml
+++ b/folio-test/modules/mod-copycat/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-copycat/replicas.yaml
+++ b/folio-test/modules/mod-copycat/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-courses/application.yaml
+++ b/folio-test/modules/mod-courses/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-courses/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-courses/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.5.43
   - ref: values

--- a/folio-test/modules/mod-courses/overrides.yaml
+++ b/folio-test/modules/mod-courses/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-courses/replicas.yaml
+++ b/folio-test/modules/mod-courses/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-data-export-spring/overrides.yaml
+++ b/folio-test/modules/mod-data-export-spring/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 1
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-data-export-worker/overrides.yaml
+++ b/folio-test/modules/mod-data-export-worker/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 1
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-data-export/overrides.yaml
+++ b/folio-test/modules/mod-data-export/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 1
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-data-import/overrides.yaml
+++ b/folio-test/modules/mod-data-import/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 1
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-di-converter-storage/application.yaml
+++ b/folio-test/modules/mod-di-converter-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-di-converter-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-di-converter-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.2.43
   - ref: values

--- a/folio-test/modules/mod-di-converter-storage/overrides.yaml
+++ b/folio-test/modules/mod-di-converter-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-di-converter-storage/replicas.yaml
+++ b/folio-test/modules/mod-di-converter-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-ebsconet/application.yaml
+++ b/folio-test/modules/mod-ebsconet/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-ebsconet/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.49
   - ref: values

--- a/folio-test/modules/mod-ebsconet/overrides.yaml
+++ b/folio-test/modules/mod-ebsconet/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-ebsconet/replicas.yaml
+++ b/folio-test/modules/mod-ebsconet/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-email/application.yaml
+++ b/folio-test/modules/mod-email/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-email/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-email/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.16.48
   - ref: values

--- a/folio-test/modules/mod-email/overrides.yaml
+++ b/folio-test/modules/mod-email/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-email/replicas.yaml
+++ b/folio-test/modules/mod-email/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-entities-links/application.yaml
+++ b/folio-test/modules/mod-entities-links/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-entities-links/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-entities-links/replicas.yaml
       - $values/folio-test/modules/mod-entities-links/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.43

--- a/folio-test/modules/mod-entities-links/overrides.yaml
+++ b/folio-test/modules/mod-entities-links/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-entities-links/replicas.yaml
+++ b/folio-test/modules/mod-entities-links/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-erm-usage-harvester/overrides.yaml
+++ b/folio-test/modules/mod-erm-usage-harvester/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 1
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-erm-usage/application.yaml
+++ b/folio-test/modules/mod-erm-usage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-erm-usage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.6.48
   - ref: values

--- a/folio-test/modules/mod-erm-usage/overrides.yaml
+++ b/folio-test/modules/mod-erm-usage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-erm-usage/replicas.yaml
+++ b/folio-test/modules/mod-erm-usage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-eusage-reports/application.yaml
+++ b/folio-test/modules/mod-eusage-reports/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-eusage-reports/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.0.48
   - ref: values

--- a/folio-test/modules/mod-eusage-reports/overrides.yaml
+++ b/folio-test/modules/mod-eusage-reports/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-eusage-reports/replicas.yaml
+++ b/folio-test/modules/mod-eusage-reports/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-event-config/application.yaml
+++ b/folio-test/modules/mod-event-config/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-event-config/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-event-config/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.6.48
   - ref: values

--- a/folio-test/modules/mod-event-config/overrides.yaml
+++ b/folio-test/modules/mod-event-config/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-event-config/replicas.yaml
+++ b/folio-test/modules/mod-event-config/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-feesfines/application.yaml
+++ b/folio-test/modules/mod-feesfines/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-feesfines/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-feesfines/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 19.0.48
   - ref: values

--- a/folio-test/modules/mod-feesfines/overrides.yaml
+++ b/folio-test/modules/mod-feesfines/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-feesfines/replicas.yaml
+++ b/folio-test/modules/mod-feesfines/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-finance-storage/application.yaml
+++ b/folio-test/modules/mod-finance-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-finance-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-finance-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 8.5.48
   - ref: values

--- a/folio-test/modules/mod-finance-storage/overrides.yaml
+++ b/folio-test/modules/mod-finance-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-finance-storage/replicas.yaml
+++ b/folio-test/modules/mod-finance-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-finance/application.yaml
+++ b/folio-test/modules/mod-finance/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-finance/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-finance/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.8.48
   - ref: values

--- a/folio-test/modules/mod-finance/overrides.yaml
+++ b/folio-test/modules/mod-finance/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-finance/replicas.yaml
+++ b/folio-test/modules/mod-finance/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-fqm-manager/application.yaml
+++ b/folio-test/modules/mod-fqm-manager/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-fqm-manager/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-fqm-manager/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.1.41
   - ref: values

--- a/folio-test/modules/mod-fqm-manager/overrides.yaml
+++ b/folio-test/modules/mod-fqm-manager/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-fqm-manager/replicas.yaml
+++ b/folio-test/modules/mod-fqm-manager/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-gobi/application.yaml
+++ b/folio-test/modules/mod-gobi/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-gobi/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-gobi/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.7.49
   - ref: values

--- a/folio-test/modules/mod-gobi/overrides.yaml
+++ b/folio-test/modules/mod-gobi/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-gobi/replicas.yaml
+++ b/folio-test/modules/mod-gobi/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-graphql/application.yaml
+++ b/folio-test/modules/mod-graphql/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-graphql/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-graphql/probes.yaml
+      - $values/folio-test/modules/mod-graphql/replicas.yaml
       - $values/folio-test/modules/mod-graphql/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.12.48

--- a/folio-test/modules/mod-graphql/overrides.yaml
+++ b/folio-test/modules/mod-graphql/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-graphql/replicas.yaml
+++ b/folio-test/modules/mod-graphql/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-inventory-storage/application.yaml
+++ b/folio-test/modules/mod-inventory-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-inventory-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-inventory-storage/replicas.yaml
       - $values/folio-test/modules/mod-inventory-storage/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 27.1.42

--- a/folio-test/modules/mod-inventory-storage/extra_env.yaml
+++ b/folio-test/modules/mod-inventory-storage/extra_env.yaml
@@ -1,8 +1,6 @@
 # mod-inventory-storage requires REPLICATION_FACTOR to be set as env variable because it creates necessary topics on its own
 # and it won’t be overridden by the kafka configured setting.
 # In addition to setting the number of pod replicas, REPLICATION_FACTOR env is set using the replicaCount setting
-replicaCount: 3
-
 # Include the extraEnvVars from the chart, and then add our REPLICATION_FACTOR.
 extraEnvVars: |
   - name: DB_EXPLAIN_QUERY_THRESHOLD

--- a/folio-test/modules/mod-inventory-storage/overrides.yaml
+++ b/folio-test/modules/mod-inventory-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-inventory-storage/replicas.yaml
+++ b/folio-test/modules/mod-inventory-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-inventory-update/application.yaml
+++ b/folio-test/modules/mod-inventory-update/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-inventory-update/probes.yaml
+      - $values/folio-test/modules/mod-inventory-update/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.2.50
   - ref: values

--- a/folio-test/modules/mod-inventory-update/overrides.yaml
+++ b/folio-test/modules/mod-inventory-update/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-inventory-update/replicas.yaml
+++ b/folio-test/modules/mod-inventory-update/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-inventory/application.yaml
+++ b/folio-test/modules/mod-inventory/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-inventory/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-inventory/probes.yaml
+      - $values/folio-test/modules/mod-inventory/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 20.2.43
   - ref: values

--- a/folio-test/modules/mod-inventory/overrides.yaml
+++ b/folio-test/modules/mod-inventory/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-inventory/replicas.yaml
+++ b/folio-test/modules/mod-inventory/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-invoice-storage/application.yaml
+++ b/folio-test/modules/mod-invoice-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-invoice-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-invoice-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.7.49
   - ref: values

--- a/folio-test/modules/mod-invoice-storage/overrides.yaml
+++ b/folio-test/modules/mod-invoice-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-invoice-storage/replicas.yaml
+++ b/folio-test/modules/mod-invoice-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-invoice/application.yaml
+++ b/folio-test/modules/mod-invoice/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-invoice/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-invoice/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.8.41
   - ref: values

--- a/folio-test/modules/mod-invoice/overrides.yaml
+++ b/folio-test/modules/mod-invoice/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-invoice/replicas.yaml
+++ b/folio-test/modules/mod-invoice/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-kb-ebsco-java/application.yaml
+++ b/folio-test/modules/mod-kb-ebsco-java/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-kb-ebsco-java/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.0.48
   - ref: values

--- a/folio-test/modules/mod-kb-ebsco-java/overrides.yaml
+++ b/folio-test/modules/mod-kb-ebsco-java/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-kb-ebsco-java/replicas.yaml
+++ b/folio-test/modules/mod-kb-ebsco-java/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-licenses/application.yaml
+++ b/folio-test/modules/mod-licenses/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-licenses/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-licenses/probes.yaml
+      - $values/folio-test/modules/mod-licenses/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.0.50
   - ref: values

--- a/folio-test/modules/mod-licenses/overrides.yaml
+++ b/folio-test/modules/mod-licenses/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-licenses/replicas.yaml
+++ b/folio-test/modules/mod-licenses/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-linked-data/application.yaml
+++ b/folio-test/modules/mod-linked-data/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-linked-data/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.26
   - ref: values

--- a/folio-test/modules/mod-linked-data/overrides.yaml
+++ b/folio-test/modules/mod-linked-data/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-linked-data/replicas.yaml
+++ b/folio-test/modules/mod-linked-data/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-lists/application.yaml
+++ b/folio-test/modules/mod-lists/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-lists/replicas.yaml
       - $values/folio-test/modules/mod-lists/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.1.44

--- a/folio-test/modules/mod-lists/overrides.yaml
+++ b/folio-test/modules/mod-lists/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-lists/replicas.yaml
+++ b/folio-test/modules/mod-lists/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-login-keycloak/application.yaml
+++ b/folio-test/modules/mod-login-keycloak/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-login-keycloak/replicas.yaml
       - $values/folio-test/modules/mod-login-keycloak/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51

--- a/folio-test/modules/mod-login-keycloak/overrides.yaml
+++ b/folio-test/modules/mod-login-keycloak/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-login-keycloak/replicas.yaml
+++ b/folio-test/modules/mod-login-keycloak/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-marc-migrations/application.yaml
+++ b/folio-test/modules/mod-marc-migrations/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-marc-migrations/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values

--- a/folio-test/modules/mod-marc-migrations/overrides.yaml
+++ b/folio-test/modules/mod-marc-migrations/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-marc-migrations/replicas.yaml
+++ b/folio-test/modules/mod-marc-migrations/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-ncip/overrides.yaml
+++ b/folio-test/modules/mod-ncip/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-notes/application.yaml
+++ b/folio-test/modules/mod-notes/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-notes/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-notes/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.1.48
   - ref: values

--- a/folio-test/modules/mod-notes/overrides.yaml
+++ b/folio-test/modules/mod-notes/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-notes/replicas.yaml
+++ b/folio-test/modules/mod-notes/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-notify/application.yaml
+++ b/folio-test/modules/mod-notify/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-notify/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-notify/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.48
   - ref: values

--- a/folio-test/modules/mod-notify/overrides.yaml
+++ b/folio-test/modules/mod-notify/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-notify/replicas.yaml
+++ b/folio-test/modules/mod-notify/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-okapi-facade/overrides.yaml
+++ b/folio-test/modules/mod-okapi-facade/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-orders-storage/application.yaml
+++ b/folio-test/modules/mod-orders-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-orders-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-orders-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 13.6.49
   - ref: values

--- a/folio-test/modules/mod-orders-storage/overrides.yaml
+++ b/folio-test/modules/mod-orders-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-orders-storage/replicas.yaml
+++ b/folio-test/modules/mod-orders-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-orders/application.yaml
+++ b/folio-test/modules/mod-orders/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-orders/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-orders/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 12.7.49
   - ref: values

--- a/folio-test/modules/mod-orders/overrides.yaml
+++ b/folio-test/modules/mod-orders/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-orders/replicas.yaml
+++ b/folio-test/modules/mod-orders/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-organizations-storage/application.yaml
+++ b/folio-test/modules/mod-organizations-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-organizations-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-organizations-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 4.6.49
   - ref: values

--- a/folio-test/modules/mod-organizations-storage/overrides.yaml
+++ b/folio-test/modules/mod-organizations-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-organizations-storage/replicas.yaml
+++ b/folio-test/modules/mod-organizations-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-organizations/application.yaml
+++ b/folio-test/modules/mod-organizations/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-organizations/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-organizations/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.8.48
   - ref: values

--- a/folio-test/modules/mod-organizations/overrides.yaml
+++ b/folio-test/modules/mod-organizations/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-organizations/replicas.yaml
+++ b/folio-test/modules/mod-organizations/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-password-validator/application.yaml
+++ b/folio-test/modules/mod-password-validator/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-password-validator/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-password-validator/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.48
   - ref: values

--- a/folio-test/modules/mod-password-validator/overrides.yaml
+++ b/folio-test/modules/mod-password-validator/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-password-validator/replicas.yaml
+++ b/folio-test/modules/mod-password-validator/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-patron-blocks/application.yaml
+++ b/folio-test/modules/mod-patron-blocks/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-patron-blocks/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-patron-blocks/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.9.48
   - ref: values

--- a/folio-test/modules/mod-patron-blocks/overrides.yaml
+++ b/folio-test/modules/mod-patron-blocks/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-patron-blocks/replicas.yaml
+++ b/folio-test/modules/mod-patron-blocks/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-patron/application.yaml
+++ b/folio-test/modules/mod-patron/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-patron/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-patron/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.0.47
   - ref: values

--- a/folio-test/modules/mod-patron/overrides.yaml
+++ b/folio-test/modules/mod-patron/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-patron/replicas.yaml
+++ b/folio-test/modules/mod-patron/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-permissions/application.yaml
+++ b/folio-test/modules/mod-permissions/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-permissions/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-permissions/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 6.4.48
   - ref: values

--- a/folio-test/modules/mod-permissions/overrides.yaml
+++ b/folio-test/modules/mod-permissions/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-permissions/replicas.yaml
+++ b/folio-test/modules/mod-permissions/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-pubsub/application.yaml
+++ b/folio-test/modules/mod-pubsub/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-pubsub/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-pubsub/replicas.yaml
       - $values/folio-test/modules/mod-pubsub/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.41

--- a/folio-test/modules/mod-pubsub/overrides.yaml
+++ b/folio-test/modules/mod-pubsub/overrides.yaml
@@ -17,7 +17,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-pubsub/replicas.yaml
+++ b/folio-test/modules/mod-pubsub/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-quick-marc/overrides.yaml
+++ b/folio-test/modules/mod-quick-marc/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 1
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-reading-room/application.yaml
+++ b/folio-test/modules/mod-reading-room/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-reading-room/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values

--- a/folio-test/modules/mod-reading-room/overrides.yaml
+++ b/folio-test/modules/mod-reading-room/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-reading-room/replicas.yaml
+++ b/folio-test/modules/mod-reading-room/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-record-specifications/application.yaml
+++ b/folio-test/modules/mod-record-specifications/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-record-specifications/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.49
   - ref: values

--- a/folio-test/modules/mod-record-specifications/overrides.yaml
+++ b/folio-test/modules/mod-record-specifications/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-record-specifications/replicas.yaml
+++ b/folio-test/modules/mod-record-specifications/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-remote-storage/application.yaml
+++ b/folio-test/modules/mod-remote-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-remote-storage/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.50
   - ref: values

--- a/folio-test/modules/mod-remote-storage/overrides.yaml
+++ b/folio-test/modules/mod-remote-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-remote-storage/replicas.yaml
+++ b/folio-test/modules/mod-remote-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-reporting/application.yaml
+++ b/folio-test/modules/mod-reporting/application.yaml
@@ -17,10 +17,11 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-reporting/overrides.yaml
-      - $values/folio-test/modules/mod-reporting/extra_env.yaml
       - $values/folio-test/modules/mod-reporting/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-reporting/probes.yaml
+      - $values/folio-test/modules/mod-reporting/replicas.yaml
+      - $values/folio-test/modules/mod-reporting/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.32
   - ref: values

--- a/folio-test/modules/mod-reporting/overrides.yaml
+++ b/folio-test/modules/mod-reporting/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-reporting/replicas.yaml
+++ b/folio-test/modules/mod-reporting/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/folio-test/modules/mod-roles-keycloak/application.yaml
+++ b/folio-test/modules/mod-roles-keycloak/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-roles-keycloak/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-roles-keycloak/replicas.yaml
       - $values/folio-test/modules/mod-roles-keycloak/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51

--- a/folio-test/modules/mod-roles-keycloak/overrides.yaml
+++ b/folio-test/modules/mod-roles-keycloak/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-roles-keycloak/replicas.yaml
+++ b/folio-test/modules/mod-roles-keycloak/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-rtac/application.yaml
+++ b/folio-test/modules/mod-rtac/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-rtac/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-rtac/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.5.48
   - ref: values

--- a/folio-test/modules/mod-rtac/overrides.yaml
+++ b/folio-test/modules/mod-rtac/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-rtac/replicas.yaml
+++ b/folio-test/modules/mod-rtac/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-scheduler/application.yaml
+++ b/folio-test/modules/mod-scheduler/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-scheduler/replicas.yaml
       - $values/folio-test/modules/mod-scheduler/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51

--- a/folio-test/modules/mod-scheduler/overrides.yaml
+++ b/folio-test/modules/mod-scheduler/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-scheduler/replicas.yaml
+++ b/folio-test/modules/mod-scheduler/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-search/application.yaml
+++ b/folio-test/modules/mod-search/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-search/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-search/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.1.44
   - ref: values

--- a/folio-test/modules/mod-search/overrides.yaml
+++ b/folio-test/modules/mod-search/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-search/replicas.yaml
+++ b/folio-test/modules/mod-search/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-sender/application.yaml
+++ b/folio-test/modules/mod-sender/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-sender/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-sender/probes.yaml
+      - $values/folio-test/modules/mod-sender/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.11.48
   - ref: values

--- a/folio-test/modules/mod-sender/overrides.yaml
+++ b/folio-test/modules/mod-sender/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-sender/replicas.yaml
+++ b/folio-test/modules/mod-sender/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-serials-management/application.yaml
+++ b/folio-test/modules/mod-serials-management/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-serials-management/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-serials-management/probes.yaml
+      - $values/folio-test/modules/mod-serials-management/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.48
   - ref: values

--- a/folio-test/modules/mod-serials-management/overrides.yaml
+++ b/folio-test/modules/mod-serials-management/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-serials-management/replicas.yaml
+++ b/folio-test/modules/mod-serials-management/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-service-interaction/application.yaml
+++ b/folio-test/modules/mod-service-interaction/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-service-interaction/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/modules/mod-service-interaction/probes.yaml
+      - $values/folio-test/modules/mod-service-interaction/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.0.50
   - ref: values

--- a/folio-test/modules/mod-service-interaction/overrides.yaml
+++ b/folio-test/modules/mod-service-interaction/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-service-interaction/replicas.yaml
+++ b/folio-test/modules/mod-service-interaction/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-settings/application.yaml
+++ b/folio-test/modules/mod-settings/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-settings/replicas.yaml
       - $values/folio-test/modules/mod-settings/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.0.50

--- a/folio-test/modules/mod-settings/overrides.yaml
+++ b/folio-test/modules/mod-settings/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-settings/replicas.yaml
+++ b/folio-test/modules/mod-settings/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-source-record-manager/application.yaml
+++ b/folio-test/modules/mod-source-record-manager/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-source-record-manager/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-source-record-manager/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.8.43
   - ref: values

--- a/folio-test/modules/mod-source-record-manager/overrides.yaml
+++ b/folio-test/modules/mod-source-record-manager/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-source-record-manager/replicas.yaml
+++ b/folio-test/modules/mod-source-record-manager/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-source-record-storage/application.yaml
+++ b/folio-test/modules/mod-source-record-storage/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-source-record-storage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-source-record-storage/replicas.yaml
       - $values/folio-test/modules/mod-source-record-storage/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 5.8.44

--- a/folio-test/modules/mod-source-record-storage/overrides.yaml
+++ b/folio-test/modules/mod-source-record-storage/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-source-record-storage/replicas.yaml
+++ b/folio-test/modules/mod-source-record-storage/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-tags/application.yaml
+++ b/folio-test/modules/mod-tags/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-tags/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-tags/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.1.48
   - ref: values

--- a/folio-test/modules/mod-tags/overrides.yaml
+++ b/folio-test/modules/mod-tags/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-tags/replicas.yaml
+++ b/folio-test/modules/mod-tags/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-template-engine/application.yaml
+++ b/folio-test/modules/mod-template-engine/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-template-engine/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 1.19.49
   - ref: values

--- a/folio-test/modules/mod-template-engine/overrides.yaml
+++ b/folio-test/modules/mod-template-engine/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-template-engine/replicas.yaml
+++ b/folio-test/modules/mod-template-engine/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-user-import/application.yaml
+++ b/folio-test/modules/mod-user-import/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-user-import/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-user-import/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 3.8.48
   - ref: values

--- a/folio-test/modules/mod-user-import/overrides.yaml
+++ b/folio-test/modules/mod-user-import/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-user-import/replicas.yaml
+++ b/folio-test/modules/mod-user-import/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-users-bl/application.yaml
+++ b/folio-test/modules/mod-users-bl/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-users-bl/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-users-bl/replicas.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 7.6.48
   - ref: values

--- a/folio-test/modules/mod-users-bl/overrides.yaml
+++ b/folio-test/modules/mod-users-bl/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-users-bl/replicas.yaml
+++ b/folio-test/modules/mod-users-bl/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-users-keycloak/application.yaml
+++ b/folio-test/modules/mod-users-keycloak/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-users-keycloak/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-users-keycloak/replicas.yaml
       - $values/folio-test/modules/mod-users-keycloak/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 0.0.51

--- a/folio-test/modules/mod-users-keycloak/overrides.yaml
+++ b/folio-test/modules/mod-users-keycloak/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-users-keycloak/replicas.yaml
+++ b/folio-test/modules/mod-users-keycloak/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-users/application.yaml
+++ b/folio-test/modules/mod-users/application.yaml
@@ -20,6 +20,7 @@ spec:
       - $values/folio-test/modules/mod-users/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
+      - $values/folio-test/modules/mod-users/replicas.yaml
       - $values/folio-test/modules/mod-users/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 19.3.41

--- a/folio-test/modules/mod-users/overrides.yaml
+++ b/folio-test/modules/mod-users/overrides.yaml
@@ -27,7 +27,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 3
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/folio-test/modules/mod-users/replicas.yaml
+++ b/folio-test/modules/mod-users/replicas.yaml
@@ -1,0 +1,1 @@
+replicaCount: 2

--- a/folio-test/modules/mod-z3950/overrides.yaml
+++ b/folio-test/modules/mod-z3950/overrides.yaml
@@ -24,7 +24,6 @@ integrations:
     enabled: false
 podSecurityContext:
   fsGroup: 2000
-replicaCount: 2
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
- Reset and reran the create_modules_values script to remove the replicaSet value from the overrides file.
- The default RS (1) is used from the helm charts so we can always reset to 1 if the --prod-replicasets flag is not applied.
- Place a file called replicas.yaml in each module folder that will have either more or less than 1 rs.