### PR TITLE
Removes grep from getting SIDECAR_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ curl -X POST --location "$KONG_URL/roles/users" -H "Authorization: Bearer $TOKEN
 ## Sidecar Client Login
 ### Get the sidecar client vault secret from secret/folio/sul and set the sidecar secret as SIDECAR_SECRET
 ```
-export SIDECAR_SECRET=$(kubectl -n $namespace exec -it vault-0 -- vault kv get -field=sidecar-module-access-client secret/folio/sul)
+export SIDECAR_SECRET=$(kubectl -n $namespace exec -it vault-0 -- vault kv get -format=json secret/folio/sul | jq -jrc '.data.data."sidecar-module-access-client"')
 ```
 
 ### Get the sidecar token from the tenant (sul) keycloak realm


### PR DESCRIPTION
Doesn't get us there with removing the newline char....

We could instead try `kubectl -n $namespace exec -it vault-0 -- vault kv get -format=json secret/folio/sul | jq -jrc '.data.data."sidecar-module-access-client"'` but still trying to pipe that to `sed 's/\n//g'` is not removing the newline char. 🤷 