### PR TITLE
Allow scripts to process all descriptor files at the same time

### DIFF
--- a/create_applications.py
+++ b/create_applications.py
@@ -10,7 +10,7 @@ parser = argparse.ArgumentParser(
                     description="Create ArgoCD applications for FOLIO using application descriptors",
                     epilog="-------")
 
-parser.add_argument("filename", nargs="*", help="the application descriptor JSON file to process")
+parser.add_argument("filename", nargs="*", help="The application descriptor JSON file or files to process. If not provided, all JSON files in the namespace directory will be processed.")
 parser.add_argument("-m", "--modules", help="a list of modules to install, each with -m flag", nargs="+", action="extend")
 parser.add_argument("-n", "--namespace", required=True, help="the Kubernetes namespace for the applications")
 parser.add_argument("-p", "--prod_replicasets", action="store_true", default=False, help="use production-level replicaset counts, else replicaCount=1")

--- a/create_module_values.py
+++ b/create_module_values.py
@@ -10,9 +10,9 @@ parser = argparse.ArgumentParser(
                     description='Create FOLIO Eureka module values using application descriptors',
                     epilog='-------')
 
-parser.add_argument('filename', nargs='*', help='the application descriptor JSON file to process')
+parser.add_argument('filename', nargs='*', help='The application descriptor JSON file or files to process. If not provided, all JSON files in the namespace directory will be processed.')
 parser.add_argument('-m', '--modules', help='a list of modules to install, each with -m flag', nargs="+", action='extend')
-parser.add_argument('-n', '--namespace', required=True, help='the Kubernetes namespace for the applications')
+parser.add_argument('-n', '--namespace', required=True, help='the Kubernetes namespace for the applications.')
 
 args = parser.parse_args()
 


### PR DESCRIPTION
If you include the namespace without any file args it will process all of the descriptor files in the namespace dir. You can also pass in multiple descriptor files at the same time as separate positional args.