### PR TITLE
Pubsub problems

### DIFF
--- a/folio-test/modules/mod-pubsub/extra_env.yaml
+++ b/folio-test/modules/mod-pubsub/extra_env.yaml
@@ -5,3 +5,8 @@ extraEnvVars: |
     value: "false"
   - name: SYSTEM_USER_NAME
     value: "mod-pubsub"
+  - name: SYSTEM_USER_PASSWORD
+    valueFrom:
+      secretKeyRef:
+          name: mod-pubsub-system-user
+          key: SYSTEM_USER_PASSWORD


### PR DESCRIPTION
I updated `puppet/application/folio-k8s/folio-test/mod-pubsub-system-user` to have the password that is in `secret/folio/sul` for mod-pubsub. It looks like this worked.
Before, the logs showed:
```
23:33:24 [] [] [] [] INFO  RestUtil             Sending POST for http://localhost:8082/authn/login-with-expiry
23:33:24 [] [] [] [] INFO  RestUtil             Response received with statusCode 401
```
I tried chaning the SYSTEM_USER_NAME to mod-pubsub but then the module complained about not knowing the password. So I added the password back, using the value from vault/keycloak.

Now seeing this in the logs:
```
23:46:52 [] [] [] [] INFO  SecurityManagerImpl  logInWithExpiry:: Logging in, tenantId=sul
23:46:52 [] [] [] [] INFO  RestUtil             Sending POST for http://localhost:8082/authn/login-with-expiry
23:46:52 [] [] [] [] INFO  RestUtil             Response received with statusCode 201
23:46:52 [] [] [] [] INFO  SecurityManagerImpl  logInWithExpiry:: Logged in mod-pubsub user
```