### PR TITLE
Changes after testing edge modules

### DIFF
--- a/create_module_values.py
+++ b/create_module_values.py
@@ -63,7 +63,7 @@ def base_override(name, version):
     if name.startswith('edge-'):
         del data['integrations']['db']
         del data['integrations']['kafka']
-        data['integrations']['eureka-edge'] = {"enabled": True, "existingSecret": "eureka-edge"}
+        data['integrations']['eureka-edge'] = {"enabled": False}
     
     return yaml.dump(data)
 

--- a/folio-dev/modules/edge-connexion/overrides.yaml
+++ b/folio-dev/modules/edge-connexion/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 1.4.1
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-dev/modules/edge-ncip/java_opts.yaml
+++ b/folio-dev/modules/edge-ncip/java_opts.yaml
@@ -4,6 +4,6 @@ extraJavaOpts:
 - "-XX:MinRAMPercentage=80"
 - "-Dsecure_store=Ephemeral"
 - "-Drequest_timeout_ms=60000"
-- "-Dsecure_store_props=/etc/edge/edge-ephemeral.properties"
+- "-Dsecure_store_props=/etc/edge/ephemeral.properties"
 - "-Dokapi_url=http://kong:8000"
 - "-Dport=8081"

--- a/folio-dev/modules/edge-ncip/overrides.yaml
+++ b/folio-dev/modules/edge-ncip/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 1.10.2
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-dev/modules/edge-sip2/java_opts.yaml
+++ b/folio-dev/modules/edge-sip2/java_opts.yaml
@@ -1,3 +1,6 @@
+javaOpts:
+  - "-Dokapi_url=http://kong:8000"
+
 extraJavaOpts: 
 - "-XX:MaxRAMPercentage=80"
 - "-XX:MinRAMPercentage=80"

--- a/folio-dev/modules/edge-sip2/overrides.yaml
+++ b/folio-dev/modules/edge-sip2/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 3.4.2
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-stage/modules/edge-connexion/overrides.yaml
+++ b/folio-stage/modules/edge-connexion/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 1.3.1
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-stage/modules/edge-ncip/java_opts.yaml
+++ b/folio-stage/modules/edge-ncip/java_opts.yaml
@@ -4,6 +4,6 @@ extraJavaOpts:
 - "-XX:MinRAMPercentage=80"
 - "-Dsecure_store=Ephemeral"
 - "-Drequest_timeout_ms=60000"
-- "-Dsecure_store_props=/etc/edge/edge-ephemeral.properties"
+- "-Dsecure_store_props=/etc/edge/ephemeral.properties"
 - "-Dokapi_url=http://kong:8000"
 - "-Dport=8081"

--- a/folio-stage/modules/edge-ncip/overrides.yaml
+++ b/folio-stage/modules/edge-ncip/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 1.10.1
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-stage/modules/edge-ncip/service.yaml
+++ b/folio-stage/modules/edge-ncip/service.yaml
@@ -1,8 +1,6 @@
 ingress:
   enabled: true
   className: nginx
-  annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
   hosts:
     - host: "folio-ncip-stage.stanford.edu"
       paths:

--- a/folio-stage/modules/edge-sip2/java_opts.yaml
+++ b/folio-stage/modules/edge-sip2/java_opts.yaml
@@ -1,3 +1,6 @@
+javaOpts:
+  - "-Dokapi_url=http://kong:8000"
+
 extraJavaOpts: 
 - "-XX:MaxRAMPercentage=80"
 - "-XX:MinRAMPercentage=80"

--- a/folio-stage/modules/edge-sip2/overrides.yaml
+++ b/folio-stage/modules/edge-sip2/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 3.3.3
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-test/modules/edge-connexion/overrides.yaml
+++ b/folio-test/modules/edge-connexion/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 1.4.1
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-test/modules/edge-ncip/java_opts.yaml
+++ b/folio-test/modules/edge-ncip/java_opts.yaml
@@ -4,6 +4,6 @@ extraJavaOpts:
 - "-XX:MinRAMPercentage=80"
 - "-Dsecure_store=Ephemeral"
 - "-Drequest_timeout_ms=60000"
-- "-Dsecure_store_props=/etc/edge/edge-ephemeral.properties"
+- "-Dsecure_store_props=/etc/edge/ephemeral.properties"
 - "-Dokapi_url=http://kong:8000"
 - "-Dport=8081"

--- a/folio-test/modules/edge-ncip/overrides.yaml
+++ b/folio-test/modules/edge-ncip/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 1.10.2
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-test/modules/edge-sip2/java_opts.yaml
+++ b/folio-test/modules/edge-sip2/java_opts.yaml
@@ -1,3 +1,6 @@
+javaOpts:
+  - "-Dokapi_url=http://kong:8000"
+
 extraJavaOpts: 
 - "-XX:MaxRAMPercentage=80"
 - "-XX:MinRAMPercentage=80"

--- a/folio-test/modules/edge-sip2/overrides.yaml
+++ b/folio-test/modules/edge-sip2/overrides.yaml
@@ -13,8 +13,7 @@ image:
   tag: 3.4.2
 integrations:
   eureka-edge:
-    enabled: true
-    existingSecret: eureka-edge
+    enabled: false
   okapi:
     enabled: false
   systemuser:

--- a/folio-test/modules/mod-z3950/zserver_config.yaml
+++ b/folio-test/modules/mod-z3950/zserver_config.yaml
@@ -6,7 +6,7 @@ data:
   config.sul.json: |
     {
       "okapi": {
-        "url": "https://okapi-test.stanford.edu",
+        "url": "https://folio-test-api.stanford.edu",
         "tenant": "sul"
       },
       "login": {


### PR DESCRIPTION
Makes sure the edge-ncip secure store props are correct.
Edge modules do not use eureka integrations.
Removes extra nginx annotations.
Update api hostname in zserver config.