### PR TITLE
Adjusts resources based on wiki page and regenerates ArgoCD application files

### DIFF
--- a/folio-test/infrastructure/keycloak.yaml
+++ b/folio-test/infrastructure/keycloak.yaml
@@ -85,11 +85,12 @@ extraEnvVars:
   - name: BASE_LOGO_FILES_URL
     value: "http://folio-test.stanford.edu"
 proxy: "edge"
+replicaCount: 3
 resources:
   requests:
-    memory: 3072Mi
+    memory: 2250M
   limits:
-    memory: 4096Mi
+    memory: 2750M
 postgresql:
   enabled: false
 externalDatabase:

--- a/folio-test/infrastructure/kong.yaml
+++ b/folio-test/infrastructure/kong.yaml
@@ -7,7 +7,7 @@ image:
   tag: 3.9.2
   pullPolicy: Always
 useDaemonset: false
-replicaCount: 1
+replicaCount: 2
 containerSecurityContext:
   enabled: true
   seLinuxOptions: {}
@@ -133,10 +133,10 @@ kong:
   resources:
     requests:
       ephemeral-storage: 50Mi
-      memory: 15Gi
+      memory: 6144M
     limits:
       ephemeral-storage: 1Gi
-      memory: 17Gi
+      memory: 6144M
 ingressController:
   enabled: false
 migration:

--- a/folio-test/infrastructure/kong.yaml
+++ b/folio-test/infrastructure/kong.yaml
@@ -7,7 +7,7 @@ image:
   tag: 3.9.2
   pullPolicy: Always
 useDaemonset: false
-replicaCount: 2
+replicaCount: 1
 containerSecurityContext:
   enabled: true
   seLinuxOptions: {}
@@ -133,10 +133,10 @@ kong:
   resources:
     requests:
       ephemeral-storage: 50Mi
-      memory: 6144M
+      memory: 9Gi
     limits:
       ephemeral-storage: 1Gi
-      memory: 6144M
+      memory: 12Gi
 ingressController:
   enabled: false
 migration:

--- a/folio-test/modules/mgr-applications/mgr-applications.yaml
+++ b/folio-test/modules/mgr-applications/mgr-applications.yaml
@@ -18,15 +18,13 @@ integrations:
 extraJavaOpts:
   - "-Dlogging.level.root=DEBUG"
 
-replicaCount: 2
-
 resources:
   limits:
     cpu: 600m
     memory: 1024M
   requests:
     cpu: 300m
-    memory: 896M
+    memory: 512M
 
 # service:
 #   type: ClusterIP

--- a/folio-test/modules/mgr-applications/mgr-applications.yaml
+++ b/folio-test/modules/mgr-applications/mgr-applications.yaml
@@ -18,13 +18,15 @@ integrations:
 extraJavaOpts:
   - "-Dlogging.level.root=DEBUG"
 
+replicaCount: 2
+
 resources:
   limits:
     cpu: 600m
-    memory: 2Gi
+    memory: 1024M
   requests:
     cpu: 300m
-    memory: 512Mi
+    memory: 896M
 
 # service:
 #   type: ClusterIP

--- a/folio-test/modules/mgr-tenant-entitlements/mgr-tenant-entitlements.yaml
+++ b/folio-test/modules/mgr-tenant-entitlements/mgr-tenant-entitlements.yaml
@@ -15,13 +15,15 @@ integrations:
     enabled: true
     existingSecret: "kafka-credentials"
 
+replicaCount: 2
+
 resources:
   limits:
     cpu: 600m
-    memory: 2Gi
+    memory: 1024M
   requests:
     cpu: 300m
-    memory: 512Mi
+    memory: 896M
 
 extraEnvVars:
   - name: KC_JWKS_BASE_URL

--- a/folio-test/modules/mgr-tenant-entitlements/mgr-tenant-entitlements.yaml
+++ b/folio-test/modules/mgr-tenant-entitlements/mgr-tenant-entitlements.yaml
@@ -15,15 +15,13 @@ integrations:
     enabled: true
     existingSecret: "kafka-credentials"
 
-replicaCount: 2
-
 resources:
   limits:
     cpu: 600m
     memory: 1024M
   requests:
     cpu: 300m
-    memory: 896M
+    memory: 512M
 
 extraEnvVars:
   - name: KC_JWKS_BASE_URL

--- a/folio-test/modules/mgr-tenants/mgr-tenants.yaml
+++ b/folio-test/modules/mgr-tenants/mgr-tenants.yaml
@@ -15,13 +15,15 @@ integrations:
     enabled: true
     existingSecret: "kafka-credentials"
 
+replicaCount: 2
+
 resources:
   limits:
     cpu: 600m
-    memory: 2Gi
+    memory: 1024M
   requests:
     cpu: 300m
-    memory: 512Mi
+    memory: 896M
 
 extraEnvVars:
   - name: KC_JWKS_BASE_URL

--- a/folio-test/modules/mgr-tenants/mgr-tenants.yaml
+++ b/folio-test/modules/mgr-tenants/mgr-tenants.yaml
@@ -15,15 +15,13 @@ integrations:
     enabled: true
     existingSecret: "kafka-credentials"
 
-replicaCount: 2
-
 resources:
   limits:
     cpu: 600m
     memory: 1024M
   requests:
     cpu: 300m
-    memory: 896M
+    memory: 512M
 
 extraEnvVars:
   - name: KC_JWKS_BASE_URL

--- a/folio-test/modules/mod-agreements/resources.yaml
+++ b/folio-test/modules/mod-agreements/resources.yaml
@@ -4,6 +4,6 @@ resources:
     memory: 1536M
   limits:
     cpu: 1000m
-    memory: 20248M
+    memory: 2048M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-agreements/resources.yaml
+++ b/folio-test/modules/mod-agreements/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
-    cpu: 512m
-    memory: 3072M
+    cpu: 500m
+    memory: 1536M
   limits:
-    cpu: 1024m
-    memory: 4096M
+    cpu: 1000m
+    memory: 20248M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-agreements/resources.yaml
+++ b/folio-test/modules/mod-agreements/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
-    cpu: 500m
-    memory: 1536M
+    cpu: 512m
+    memory: 3072M
   limits:
-    cpu: 1000m
-    memory: 2048M
+    cpu: 1024m
+    memory: 4096M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-bulk-operations/extra_env.yaml
+++ b/folio-test/modules/mod-bulk-operations/extra_env.yaml
@@ -6,3 +6,5 @@ integrations:
 extraEnvVars: |
   - name: S3_IS_AWS
     value: 'true'
+  - name: OKAPI_URL
+    value: "http://localhost:8082"

--- a/folio-test/modules/mod-bulk-operations/extra_env.yaml
+++ b/folio-test/modules/mod-bulk-operations/extra_env.yaml
@@ -6,3 +6,5 @@ integrations:
 extraEnvVars: |
   - name: S3_IS_AWS
     value: 'true'
+  - name: OKAPI_URL
+    value: "http://kong:8000"

--- a/folio-test/modules/mod-bulk-operations/extra_env.yaml
+++ b/folio-test/modules/mod-bulk-operations/extra_env.yaml
@@ -6,5 +6,3 @@ integrations:
 extraEnvVars: |
   - name: S3_IS_AWS
     value: 'true'
-  - name: OKAPI_URL
-    value: "http://kong:8000"

--- a/folio-test/modules/mod-bulk-operations/resources.yaml
+++ b/folio-test/modules/mod-bulk-operations/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 1024m
-    memory: 2944Mi
+    memory: 2600M
   limits:
     cpu: 1248m
-    memory: 3072Mi
+    memory: 3072M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-calendar/resources.yaml
+++ b/folio-test/modules/mod-calendar/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 200m
-    memory: 1536M
+    memory: 512M
   limits:
     cpu: 300m
-    memory: 2048M
+    memory: 1024M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-calendar/resources.yaml
+++ b/folio-test/modules/mod-calendar/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 200m
-    memory: 512M
+    memory: 1536M
   limits:
     cpu: 300m
-    memory: 1024M
+    memory: 2048M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-circulation-storage/resources.yaml
+++ b/folio-test/modules/mod-circulation-storage/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 1024M
+    memory: 2592M
   limits:
     cpu: 1
-    memory: 1280M
+    memory: 2880M
 
 dbMaxPoolSize: 20

--- a/folio-test/modules/mod-circulation/resources.yaml
+++ b/folio-test/modules/mod-circulation/resources.yaml
@@ -4,6 +4,6 @@ resources:
     memory: 2592M
   limits:
     cpu: 1
-    memory: 2880
+    memory: 2880M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-circulation/resources.yaml
+++ b/folio-test/modules/mod-circulation/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 1792M
+    memory: 2592M
   limits:
     cpu: 1
-    memory: 2048M
+    memory: 2880
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-data-export-spring/resources.yaml
+++ b/folio-test/modules/mod-data-export-spring/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 250m
-    memory: 1039M
+    memory: 1844M
   limits:
     cpu: 400m
-    memory: 1900Mi
+    memory: 2048M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-data-export-worker/resources.yaml
+++ b/folio-test/modules/mod-data-export-worker/resources.yaml
@@ -1,10 +1,10 @@
 resources:
   requests:
     cpu: 300m
-    memory: 1536M
+    memory: 2800M
   limits:
     cpu: 500m
-    memory: 2048M
+    memory: 3072M
 
 dbMaxPoolSize: 10
 

--- a/folio-test/modules/mod-data-export/resources.yaml
+++ b/folio-test/modules/mod-data-export/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 100m
-    memory: 1536M
+    memory: 2480M
   limits:
     cpu: 200m
-    memory: 2048M
+    memory: 2592M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-data-import/resources.yaml
+++ b/folio-test/modules/mod-data-import/resources.yaml
@@ -1,10 +1,10 @@
 resources:
   requests:
     cpu: 275m
-    memory: 1024M
+    memory: 1844M
   limits:
     cpu: 300m
-    memory: 1280M
+    memory: 2048M
 
 dbMaxPoolSize: 10
 

--- a/folio-test/modules/mod-di-converter-storage/resources.yaml
+++ b/folio-test/modules/mod-di-converter-storage/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1280M
+    memory: 896M
   limits:
     cpu: 300m
-    memory: 1536M
+    memory: 1024M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-email/resources.yaml
+++ b/folio-test/modules/mod-email/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 768M
+    memory: 2550M
   limits:
     cpu: 200m
-    memory: 1024M
+    memory: 2800M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-email/resources.yaml
+++ b/folio-test/modules/mod-email/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 2550M
+    memory: 768M
   limits:
     cpu: 200m
-    memory: 2800M
+    memory: 1024M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-entities-links/resources.yaml
+++ b/folio-test/modules/mod-entities-links/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 2483M
+    memory: 1280M
   limits:
     cpu: 300m
-    memory: 2592M
+    memory: 1536M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-entities-links/resources.yaml
+++ b/folio-test/modules/mod-entities-links/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1280M
+    memory: 2483M
   limits:
     cpu: 300m
-    memory: 1536M
+    memory: 2592M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-erm-usage/application.yaml
+++ b/folio-test/modules/mod-erm-usage/application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-erm-usage/overrides.yaml
-      - $values/folio-test/common/resources.yaml
+      - $values/folio-test/modules/mod-erm-usage/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
       - $values/folio-test/modules/mod-erm-usage/replicas.yaml

--- a/folio-test/modules/mod-erm-usage/resources.yaml
+++ b/folio-test/modules/mod-erm-usage/resources.yaml
@@ -1,9 +1,7 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1152M
+    memory: 2550M
   limits:
     cpu: 200m
-    memory: 1440M
-
-dbMaxPoolSize: 10
+    memory: 2800M

--- a/folio-test/modules/mod-event-config/application.yaml
+++ b/folio-test/modules/mod-event-config/application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-event-config/overrides.yaml
-      - $values/folio-test/modules/mod-event-config/resources.yaml
+      - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
       - $values/folio-test/modules/mod-event-config/replicas.yaml

--- a/folio-test/modules/mod-event-config/resources.yaml
+++ b/folio-test/modules/mod-event-config/resources.yaml
@@ -1,7 +1,0 @@
-resources:
-  requests:
-    cpu: 10m
-  limits:
-    cpu: 50m
-
-dbMaxPoolSize: 10

--- a/folio-test/modules/mod-feesfines/application.yaml
+++ b/folio-test/modules/mod-feesfines/application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-feesfines/overrides.yaml
-      - $values/folio-test/modules/mod-feesfines/resources.yaml
+      - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
       - $values/folio-test/modules/mod-feesfines/replicas.yaml

--- a/folio-test/modules/mod-feesfines/resources.yaml
+++ b/folio-test/modules/mod-feesfines/resources.yaml
@@ -1,9 +1,0 @@
-resources:
-  requests:
-    cpu: 500m
-    memory: 768M
-  limits:
-    cpu: 1
-    memory: 1024M
-
-dbMaxPoolSize: 10

--- a/folio-test/modules/mod-fqm-manager/resources.yaml
+++ b/folio-test/modules/mod-fqm-manager/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1000Mi
+    memory: 2600M
   limits:
     cpu: 300m
-    memory: 1400Mi
+    memory: 3000M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-fqm-manager/resources.yaml
+++ b/folio-test/modules/mod-fqm-manager/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 150m
-    memory: 2600M
+    memory: 1000Mi
   limits:
     cpu: 300m
-    memory: 3000M
+    memory: 1400Mi
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-inventory-storage/resources.yaml
+++ b/folio-test/modules/mod-inventory-storage/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 1536M
+    memory: 3690M
   limits:
     cpu: 1
-    memory: 1792M
+    memory: 4096M
 
 dbMaxPoolSize: 20

--- a/folio-test/modules/mod-inventory/resources.yaml
+++ b/folio-test/modules/mod-inventory/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 250m
-    memory: 1536M
+    memory: 3688M
   limits:
     cpu: 500m
-    memory: 2048M
+    memory: 4096M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-invoice-storage/resources.yaml
+++ b/folio-test/modules/mod-invoice-storage/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 512M
+    memory: 1536M
   limits:
     cpu: 1
-    memory: 1024M
+    memory: 1872M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-licenses/resources.yaml
+++ b/folio-test/modules/mod-licenses/resources.yaml
@@ -1,7 +1,7 @@
 resources:
   requests:
     cpu: 500m
-    memory: 1536M
+    memory: 2312M
   limits:
     cpu: 1
     memory: 2048M

--- a/folio-test/modules/mod-linked-data/application.yaml
+++ b/folio-test/modules/mod-linked-data/application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-linked-data/overrides.yaml
-      - $values/folio-test/common/resources.yaml
+      - $values/folio-test/modules/mod-linked-data/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
       - $values/folio-test/modules/mod-linked-data/replicas.yaml

--- a/folio-test/modules/mod-linked-data/resources.yaml
+++ b/folio-test/modules/mod-linked-data/resources.yaml
@@ -1,9 +1,7 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1152M
+    memory: 1792M
   limits:
     cpu: 200m
-    memory: 1440M
-
-dbMaxPoolSize: 10
+    memory: 2048M

--- a/folio-test/modules/mod-lists/application.yaml
+++ b/folio-test/modules/mod-lists/application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-lists/overrides.yaml
-      - $values/folio-test/common/resources.yaml
+      - $values/folio-test/modules/mod-lists/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
       - $values/folio-test/modules/mod-lists/replicas.yaml

--- a/folio-test/modules/mod-lists/resources.yaml
+++ b/folio-test/modules/mod-lists/resources.yaml
@@ -1,9 +1,7 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1152M
+    memory: 2600M
   limits:
     cpu: 200m
-    memory: 1440M
-
-dbMaxPoolSize: 10
+    memory: 6000M

--- a/folio-test/modules/mod-ncip/application.yaml
+++ b/folio-test/modules/mod-ncip/application.yaml
@@ -17,9 +17,9 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-ncip/overrides.yaml
+      - $values/folio-test/common/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
-      - $values/folio-test/common/resources.yaml
       - $values/folio-test/modules/mod-ncip/java_opts.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
     targetRevision: 2.0.41

--- a/folio-test/modules/mod-orders-storage/resources.yaml
+++ b/folio-test/modules/mod-orders-storage/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
-    cpu: 1
-    memory: 979M
+    cpu: 150m
+    memory: 896M
   limits:
-    cpu: 2
-    memory: 1792M
+    cpu: 200m
+    memory: 1024M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-orders/resources.yaml
+++ b/folio-test/modules/mod-orders/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
-    cpu: 1024m
-    memory: 1600M
+    cpu: 150m
+    memory: 1740M
   limits:
-    cpu: 1248m
+    cpu: 200m
     memory: 2048M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-password-validator/resources.yaml
+++ b/folio-test/modules/mod-password-validator/resources.yaml
@@ -4,6 +4,6 @@ resources:
     memory: 866M
   limits:
     cpu: 100m
-    memory: 1900Mi
+    memory: 1440M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-permissions/resources.yaml
+++ b/folio-test/modules/mod-permissions/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 1024M
+    memory: 1544M
   limits:
     cpu: 1
-    memory: 1280M
+    memory: 1684M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-pubsub/resources.yaml
+++ b/folio-test/modules/mod-pubsub/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 768M
+    memory: 1440M
   limits:
     cpu: 1
-    memory: 1024M
+    memory: 1536M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-quick-marc/resources.yaml
+++ b/folio-test/modules/mod-quick-marc/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 500m
-    memory: 768M
+    memory: 2176M
   limits:
     cpu: 1
-    memory: 1024M
+    memory: 2288M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-record-specifications/application.yaml
+++ b/folio-test/modules/mod-record-specifications/application.yaml
@@ -17,7 +17,7 @@ spec:
     helm:
       valueFiles:
       - $values/folio-test/modules/mod-record-specifications/overrides.yaml
-      - $values/folio-test/common/resources.yaml
+      - $values/folio-test/modules/mod-record-specifications/resources.yaml
       - $values/folio-test/common/sidecar.yaml
       - $values/folio-test/common/probes.yaml
       - $values/folio-test/modules/mod-record-specifications/replicas.yaml

--- a/folio-test/modules/mod-record-specifications/resources.yaml
+++ b/folio-test/modules/mod-record-specifications/resources.yaml
@@ -1,9 +1,7 @@
 resources:
   requests:
     cpu: 150m
-    memory: 1152M
+    memory: 1592M
   limits:
     cpu: 200m
-    memory: 1440M
-
-dbMaxPoolSize: 10
+    memory: 2048M

--- a/folio-test/modules/mod-roles-keycloak/resources.yaml
+++ b/folio-test/modules/mod-roles-keycloak/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 250m
-    memory: 512M
+    memory: 1024M
   limits:
     cpu: 400m
-    memory: 1024M
+    memory: 2048M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-search/resources.yaml
+++ b/folio-test/modules/mod-search/resources.yaml
@@ -1,10 +1,10 @@
 resources:
   requests:
     cpu: 300m
-    memory: 2048M
+    memory: 2480M
   limits:
     cpu: 500m
-    memory: 3210M
+    memory: 2592M
 
 integrations:
   opensearch:

--- a/folio-test/modules/mod-service-interaction/resources.yaml
+++ b/folio-test/modules/mod-service-interaction/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
     cpu: 200m
-    memory: 1208M
+    memory: 1844M
   limits:
     cpu: 300m
-    memory: 1536M
+    memory: 2048M
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-source-record-manager/resources.yaml
+++ b/folio-test/modules/mod-source-record-manager/resources.yaml
@@ -1,9 +1,9 @@
 resources:
   requests:
-    memory: 1536M
+    memory: 4000M
     cpu: 550m
   limits:
-    memory: 1768M
+    memory: 4500M
     cpu: 650m
 
 dbMaxPoolSize: 10

--- a/folio-test/modules/mod-source-record-storage/resources.yaml
+++ b/folio-test/modules/mod-source-record-storage/resources.yaml
@@ -1,7 +1,7 @@
 resources:
   requests:
-    memory: 1900Mi
+    memory: 4000M
     cpu: 1024m
   limits:
-    memory: 2Gi
+    memory: 4500M
     cpu: 1536m


### PR DESCRIPTION
The resources are based off of data from the table at https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1407614977/Effect+of+horizontal+scaling+on+Eureka+Sunflower+non-ECS#secp1-pvt-resources

I copied the data to a spreadsheet and included/removed modules we deploy or don't deploy. The spreadsheet is at https://docs.google.com/spreadsheets/d/1-aquS857JAavGoRqbDCTXL5RMewHT3APB8Z5xVH5O9c/edit?usp=sharing . In order to deploy these applications with prod replicasets, we will need 330GB of memory in the folio-test namespace. The total memory for 1 replica each is 240GB and for prod-level 320GB. 