### PR TITLE
Add extra env variables to try to create more kafka partitions

### DIFF
--- a/folio-dev/modules/mod-source-record-storage/extra_env.yaml
+++ b/folio-dev/modules/mod-source-record-storage/extra_env.yaml
@@ -35,3 +35,11 @@ extraEnvVars: |
     value: "12"
   - name: DI_SRS_MARC_AUTHORITY_RECORD_UPDATED
     value: "12"
+  - name: DI_SRS_MARC_HOLDING_RECORD_CREATED 
+    value: "12"
+  - name: DI_SRS_MARC_AUTHORITY_RECORD_CREATED
+    value: "12"
+  - name: DI_RAW_RECORDS_CHUNK_PARSED
+    value: "12"
+  - name: DI_MARC_FOR_DELETE_RECEIVED
+    value: "12"

--- a/folio-stage/modules/mod-source-record-storage/extra_env.yaml
+++ b/folio-stage/modules/mod-source-record-storage/extra_env.yaml
@@ -35,3 +35,11 @@ extraEnvVars: |
     value: "12"
   - name: DI_SRS_MARC_AUTHORITY_RECORD_UPDATED
     value: "12"
+  - name: DI_SRS_MARC_HOLDING_RECORD_CREATED 
+    value: "12"
+  - name: DI_SRS_MARC_AUTHORITY_RECORD_CREATED
+    value: "12"
+  - name: DI_RAW_RECORDS_CHUNK_PARSED
+    value: "12"
+  - name: DI_MARC_FOR_DELETE_RECEIVED
+    value: "12"

--- a/folio-test/modules/mod-source-record-storage/extra_env.yaml
+++ b/folio-test/modules/mod-source-record-storage/extra_env.yaml
@@ -35,3 +35,11 @@ extraEnvVars: |
     value: "12"
   - name: DI_SRS_MARC_AUTHORITY_RECORD_UPDATED
     value: "12"
+  - name: DI_SRS_MARC_HOLDING_RECORD_CREATED 
+    value: "12"
+  - name: DI_SRS_MARC_AUTHORITY_RECORD_CREATED
+    value: "12"
+  - name: DI_RAW_RECORDS_CHUNK_PARSED
+    value: "12"
+  - name: DI_MARC_FOR_DELETE_RECEIVED
+    value: "12"


### PR DESCRIPTION
 These are not mentioned on the mod-srs readme but it is work trying to see if the next time we reset kafka whether these get created with 12 partitions.