### PR TITLE
Gets kraft cluster ID and controller password from kafka-credentials for folio-dev

### DIFF
--- a/folio-dev/infrastructure/kafka.yaml
+++ b/folio-dev/infrastructure/kafka.yaml
@@ -44,6 +44,10 @@ extraConfig: |
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true
 
+kraft:
+  existingClusterIdSecret: kafka-credentials
+sasl:
+  existingSecret: kafka-credentials
 listeners:
   client:
     protocol: PLAINTEXT


### PR DESCRIPTION
folio-dev got missed from this change https://github.com/sul-dlss/folio-eureka/pull/30/changes