### PR TITLE
Connects sru-backend to mod-z3950 service.

### DIFF
--- a/folio-dev/modules/mod-z3950/service.yaml
+++ b/folio-dev/modules/mod-z3950/service.yaml
@@ -48,7 +48,7 @@ extraDeploy:
     spec:
       rules:
       - backendRefs:
-        - name: sru
+        - name: mod-z3950
           port: 80
         matches:
           - path:

--- a/folio-test/modules/mod-z3950/service.yaml
+++ b/folio-test/modules/mod-z3950/service.yaml
@@ -48,7 +48,7 @@ extraDeploy:
     spec:
       rules:
       - backendRefs:
-        - name: sru
+        - name: mod-z3950
           port: 80
         matches:
           - path:


### PR DESCRIPTION
I think this change is needed. When syncing in ArgoCD, the following error occurs if backendRef is "sru": `Failed to process route rule 0 backendRef 0: service folio-dev/sru not found`