### PR TITLE
Removes edge-ncip-ip-limits

### DIFF
--- a/folio-dev/modules/edge-ncip/service.yaml
+++ b/folio-dev/modules/edge-ncip/service.yaml
@@ -44,23 +44,6 @@ extraDeploy:
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: SecurityPolicy
     metadata:
-      name: edge-ncip-ip-limits
-      namespace: folio-dev
-    spec:
-        targetRefs:
-          - kind: HTTPRoute
-            group: gateway.networking.k8s.io
-            name: edge-ncip-backend
-        authorization:
-          defaultAction: Allow
-          rules:
-            - action: Allow
-              principal:
-                clientCIDRs: []
-    ---
-    apiVersion: gateway.envoyproxy.io/v1alpha1
-    kind: SecurityPolicy
-    metadata:
       name: edge-ncip-cors
       namespace: folio-dev
     spec:

--- a/folio-stage/modules/edge-ncip/service.yaml
+++ b/folio-stage/modules/edge-ncip/service.yaml
@@ -54,23 +54,6 @@ extraDeploy:
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: SecurityPolicy
     metadata:
-      name: edge-ncip-ip-limits
-      namespace: folio-stage
-    spec:
-        targetRefs:
-          - kind: HTTPRoute
-            group: gateway.networking.k8s.io
-            name: edge-ncip-backend
-        authorization:
-          defaultAction: Allow
-          rules:
-            - action: Deny
-              principal:
-                clientCIDRs: []
-    ---
-    apiVersion: gateway.envoyproxy.io/v1alpha1
-    kind: SecurityPolicy
-    metadata:
       name: edge-ncip-cors
       namespace: folio-stage
     spec:


### PR DESCRIPTION
Having an empty clientCIDRs list is invalid.