### PR TITLE
Enable file splitting for folio-prod

### DIFF
--- a/folio-prod/infrastructure/kong.yaml
+++ b/folio-prod/infrastructure/kong.yaml
@@ -159,6 +159,25 @@ extraDeploy:
     apiVersion: gateway.envoyproxy.io/v1alpha1
     kind: SecurityPolicy
     metadata:
+      name: kong-cors
+      namespace: folio-test
+    spec:
+        targetRefs:
+          - kind: HTTPRoute
+            group: gateway.networking.k8s.io
+            name: kong-backend
+        cors:
+          allowOrigins:
+          - "*"
+          allowMethods:
+          - GET
+          - OPTIONS
+          - POST
+          - PUT
+  - |
+    apiVersion: gateway.envoyproxy.io/v1alpha1
+    kind: SecurityPolicy
+    metadata:
       name: kong-ip-limits
     spec:
       targetRefs:

--- a/folio-prod/modules/mod-data-import/resources.yaml
+++ b/folio-prod/modules/mod-data-import/resources.yaml
@@ -13,13 +13,13 @@ integrations:
     enabled: true
     existingSecret: "s3-credentials"
 
-# extraEnvVars: |
-#   - name: SPLIT_FILES_ENABLED
-#     value: "true"
-#   - name: AWS_SDK
-#     value: "true"
-#   - name: S3_FORCEPATHSTYLE
-#     value: "true"
+extraEnvVars: |
+  - name: SPLIT_FILES_ENABLED
+    value: "true"
+  - name: AWS_SDK
+    value: "true"
+  - name: RECORDS_PER_SPLIT_FILE
+    value: "500"
 
 # extraVolumes:
 #   data-import-uploads:


### PR DESCRIPTION
To be merged after file-splitting testing is complete, and after prod is upgraded to eureka/sunflower.