### PR TITLE
Removes port 8443 for Envoy prod rollout

### DIFF
--- a/folio-dev/modules/mod-z3950/zserver_config.yaml
+++ b/folio-dev/modules/mod-z3950/zserver_config.yaml
@@ -6,7 +6,7 @@ data:
   config.sul.json: |
     {
       "okapi": {
-        "url": "https://kong-folio-dev.stanford.edu:8443",
+        "url": "https://folio-dev-api.stanford.edu",
         "tenant": "sul"
       },
       "login": {

--- a/folio-stage/infrastructure/keycloak.yaml
+++ b/folio-stage/infrastructure/keycloak.yaml
@@ -29,7 +29,7 @@ extraEnvVars:
   - name: FIPS
     value: "false"
   - name: KC_HOSTNAME
-    value: "https://keycloak-folio-stage.stanford.edu:8443"
+    value: "https://keycloak-folio-stage.stanford.edu"
   - name: KC_HOSTNAME_DEBUG
     value: "true"
   - name: KC_FOLIO_BE_ADMIN_CLIENT_ID
@@ -83,7 +83,7 @@ extraEnvVars:
         name: keycloak-credentials
         key: KC_BOOTSTRAP_ADMIN_PASSWORD
   - name: BASE_LOGO_FILES_URL
-    value: "http://folio-stage.stanford.edu:8443"
+    value: "http://folio-stage.stanford.edu"
 proxy: "edge"
 resources:
   requests:

--- a/folio-stage/infrastructure/kong.yaml
+++ b/folio-stage/infrastructure/kong.yaml
@@ -113,7 +113,7 @@ kong:
   - name: KONG_NGINX_HTTP_LARGE_CLIENT_HEADER_BUFFERS
     value: "4 16k"
   - name: KONG_ADMIN_GUI_API_URL
-    value: "https://folio-stage-api.stanford.edu:8443"
+    value: "https://folio-stage-api.stanford.edu"
   - name: KONG_NGINX_HTTPS_LARGE_CLIENT_HEADER_BUFFERS
     value: "4 16k"
   - name: KONG_PROXY_LISTEN


### PR DESCRIPTION
Also found an old URL in folio-dev.