### PR TITLE
Pull back kafka poll interval and threads

### DIFF
--- a/folio-dev/infrastructure/kafka.yaml
+++ b/folio-dev/infrastructure/kafka.yaml
@@ -39,9 +39,8 @@ extraConfig: |
   default.replication.factor=3
   log.retention.hours=72
   log.retention.bytes=6442000000
-  num.network.threads=8
-  num.io.threads=12
-  max.poll.interval.ms=600000
+  num.network.threads=24
+  num.io.threads=24
 
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true

--- a/folio-dev/infrastructure/kafka.yaml
+++ b/folio-dev/infrastructure/kafka.yaml
@@ -41,7 +41,7 @@ extraConfig: |
   log.retention.bytes=6442000000
   num.network.threads=8
   num.io.threads=12
-  max.poll.interval.ms=1800000
+  max.poll.interval.ms=600000
 
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true

--- a/folio-prod/infrastructure/kafka.yaml
+++ b/folio-prod/infrastructure/kafka.yaml
@@ -40,7 +40,7 @@ extraConfig: |
   log.retention.bytes=6442000000
   num.network.threads=8
   num.io.threads=12
-  max.poll.interval.ms=1800000
+  max.poll.interval.ms=600000
   deleteTopicEnable=true
 
 kraft:

--- a/folio-prod/infrastructure/kafka.yaml
+++ b/folio-prod/infrastructure/kafka.yaml
@@ -38,9 +38,8 @@ extraConfig: |
   default.replication.factor=3
   log.retention.hours=72
   log.retention.bytes=6442000000
-  num.network.threads=8
-  num.io.threads=12
-  max.poll.interval.ms=600000
+  num.network.threads=24
+  num.io.threads=24
   deleteTopicEnable=true
 
 kraft:

--- a/folio-prod/modules/mod-source-record-manager/java_opts.yaml
+++ b/folio-prod/modules/mod-source-record-manager/java_opts.yaml
@@ -3,3 +3,4 @@ extraJavaOpts:
   - "-XX:MinRAMPercentage=80" 
   - "-Dsrm.kafka.DataImportConsumer.loadLimit=8"
   - "-Dsrm.kafka.DataImportConsumer.globalLoadLimit=64"
+

--- a/folio-stage/infrastructure/kafka.yaml
+++ b/folio-stage/infrastructure/kafka.yaml
@@ -39,9 +39,8 @@ extraConfig: |
   default.replication.factor=3
   log.retention.hours=72
   log.retention.bytes=6442000000
-  num.network.threads=8
-  num.io.threads=12
-  max.poll.interval.ms=600000
+  num.network.threads=24
+  num.io.threads=24
 
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true

--- a/folio-stage/infrastructure/kafka.yaml
+++ b/folio-stage/infrastructure/kafka.yaml
@@ -41,7 +41,7 @@ extraConfig: |
   log.retention.bytes=6442000000
   num.network.threads=8
   num.io.threads=12
-  max.poll.interval.ms=1800000
+  max.poll.interval.ms=600000
 
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true

--- a/folio-test/infrastructure/kafka.yaml
+++ b/folio-test/infrastructure/kafka.yaml
@@ -39,9 +39,8 @@ extraConfig: |
   default.replication.factor=3
   log.retention.hours=72
   log.retention.bytes=6442000000
-  num.network.threads=8
-  num.io.threads=12
-  max.poll.interval.ms=600000
+  num.network.threads=24
+  num.io.threads=24
 
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true

--- a/folio-test/infrastructure/kafka.yaml
+++ b/folio-test/infrastructure/kafka.yaml
@@ -41,7 +41,7 @@ extraConfig: |
   log.retention.bytes=6442000000
   num.network.threads=8
   num.io.threads=12
-  max.poll.interval.ms=1800000
+  max.poll.interval.ms=600000
 
 # Add to extraConfig to delete topics if needed
 # deleteTopicEnable=true


### PR DESCRIPTION
A 30 min. interval is somewhat excessive. Since it does not seem to help maybe pull it back to 10 min.