### PR TITLE
Create temp table of expired resource_ids_job rows

### DIFF
--- a/db-scripts/mod-search-cleanup-configmap.yaml
+++ b/db-scripts/mod-search-cleanup-configmap.yaml
@@ -19,10 +19,16 @@ data:
             RETURNING temp_table_name
           )
           SELECT temp_table_name FROM deleted;")
-
+      
     if [ -z "$TABLES" ]; then
       echo "No expired resource_ids_job rows found."
       exit 0
+    else
+      echo "Found expired resource_ids_job rows for tables."
+      INSERT_SQL=$(printf "INSERT INTO public.mod_search_cleanup_log (temp_table_name) VALUES ('%s');\n" $TABLES)
+      PGPASSWORD=$DB_PASSWORD psql $PGCONN \
+        -c "CREATE TABLE IF NOT EXISTS public.mod_search_cleanup_log (temp_table_name TEXT, cleaned_at TIMESTAMPTZ DEFAULT NOW());" \
+        -c "$INSERT_SQL"
     fi
 
     for tbl in $TABLES; do


### PR DESCRIPTION
I thought again about doing the select and then the subsequent drop and delete row, but that would dounel the number of sql query statements being made, making the job take longer to run. Instead, after the initial delete with returning column values, this change saves them to a `public.mod_search_cleanup_log` table with a timestamp.