### PR TITLE
Remove creation of log table

### DIFF
--- a/db-scripts/mod-search-cleanup-configmap.yaml
+++ b/db-scripts/mod-search-cleanup-configmap.yaml
@@ -23,16 +23,9 @@ data:
     if [ -z "$TABLES" ]; then
       echo "No expired resource_ids_job rows found."
       exit 0
-    else
-      echo "Found expired resource_ids_job rows for tables."
-      INSERT_SQL=$(printf "INSERT INTO public.mod_search_cleanup_log (temp_table_name) VALUES ('%s');\n" $TABLES)
-      PGPASSWORD=$DB_PASSWORD psql $PGCONN \
-        -c "CREATE TABLE IF NOT EXISTS public.mod_search_cleanup_log (temp_table_name TEXT, cleaned_at TIMESTAMPTZ DEFAULT NOW());" \
-        -c "$INSERT_SQL"
     fi
 
-    for tbl in $TABLES; do
-      echo "Dropping table: sul_mod_search.$tbl"
-      PGPASSWORD=$DB_PASSWORD psql $PGCONN \
-        -c "DROP TABLE IF EXISTS sul_mod_search.\"$tbl\";"
-    done
+    echo "Dropping $( echo "$TABLES" | wc -w | tr -d ' ') tables..."
+    printf 'DROP TABLE IF EXISTS sul_mod_search."%s";\n' $TABLES \
+      | PGPASSWORD=$DB_PASSWORD psql $PGCONN
+    echo "Done."


### PR DESCRIPTION
If there are too many entries the temp table creation fails and the script exists without dropping any tables. Better to just run it without trying to create an aftifact.