### PR TITLE
Add credentials for periodic harvesting

### DIFF
--- a/folio-prod/modules/mod-erm-usage-harvester/extra_env.yaml
+++ b/folio-prod/modules/mod-erm-usage-harvester/extra_env.yaml
@@ -1,3 +1,13 @@
 extraEnvVars: |
   - name: OKAPI_URL
     value: "http://localhost:8082"
+  - name: SUL_USER_NAME
+    valuefrom:
+      secretKeyRef:
+        name: folio-eureka
+        key: SUL_ERM_USER_NAME
+  - name: SUL_USER_PASSWORD
+    valuefrom:
+      secretKeyRef:
+        name: folio-eureka
+        key: SUL_ERM_USER_PASS


### PR DESCRIPTION
To get periodic harvesting working under Sunflower-Eureka with 5.1.1 we still needed to go through the [documented setup](https://github.com/folio-org/mod-erm-usage-harvester/tree/v5.1.1#periodic-harvesting) for each tenant. Once we are able to move to the newer app-erm-usage version that bundles 5.2.0, we can remove this change since 5.2.0 delegates system-user auth to the sidecar and removes the explicit login altogether.