### PR TITLE
Downgrades app-z3950

### DIFF
--- a/folio-dev/application-descriptor-z3950.json
+++ b/folio-dev/application-descriptor-z3950.json
@@ -1,7 +1,7 @@
 {
-  "id": "app-z3950-1.1.0",
+  "id": "app-z3950-1.0.1",
   "name": "app-z3950",
-  "version": "1.1.0",
+  "version": "1.0.1",
   "description": "Application for mod-z3950",
   "platform": "complete",
   "dependencies": [
@@ -13,12 +13,12 @@
   "modules": [
     {
       "name": "mod-z3950",
-      "version": "4.4.1"
+      "version": "4.3.0"
     }
   ],
   "moduleDescriptors": [
     {
-      "id": "mod-z3950-4.4.1",
+      "id": "mod-z3950-4.3.0",
       "name": "Z39.50/SRU/SRW server for FOLIO",
       "provides": [
         {
@@ -42,7 +42,7 @@
         },
         {
           "id": "graphql",
-          "version": "1.5"
+          "version": "1.4"
         },
         {
           "id": "source-storage-source-records",
@@ -51,7 +51,7 @@
       ],
       "launchDescriptor": {
         "dockerImage": "folioorg/mod-z3950:4.3.0",
-        "dockerPull": false,
+        "dockerPull": true,
         "dockerArgs": {
           "HostConfig": {
             "Memory": 402653184,

--- a/folio-dev/modules/mod-z3950/overrides.yaml
+++ b/folio-dev/modules/mod-z3950/overrides.yaml
@@ -10,7 +10,7 @@ eureka:
     value: 'false'
 image:
   repository: folioorg/mod-z3950
-  tag: 4.4.1
+  tag: 4.3.0
 integrations:
   db:
     enabled: true


### PR DESCRIPTION
The latest mod-z3950 version requires graphql 1.5 interface, which is available in Trillium.