### PR TITLE
folio-test upgrade patches

### DIFF
--- a/folio-test/infrastructure/elasticsearch_application.yaml
+++ b/folio-test/infrastructure/elasticsearch_application.yaml
@@ -11,7 +11,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: folio-test
   sources:
-    - repoURL: oci://registry-1.docker.io/bitnamicharts/elasticsearch
+    - repoURL: https://charts.bitnami.com/bitnami
       chart: elasticsearch
       targetRevision: 19.6.0
       helm:

--- a/folio-test/infrastructure/elasticsearch_application.yaml
+++ b/folio-test/infrastructure/elasticsearch_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: elasticsearch
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/kafka_application.yaml
+++ b/folio-test/infrastructure/kafka_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: kafka-folio-test
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/keycloak_application.yaml
+++ b/folio-test/infrastructure/keycloak_application.yaml
@@ -11,7 +11,7 @@ spec:
     server: https://kubernetes.default.svc
   sources:
     - chart: keycloak
-      repoURL: oci://registry-1.docker.io/bitnamicharts/keycloak
+      repoURL: https://charts.bitnami.com/bitnami
       targetRevision: 24.7.4
       helm:
         valueFiles:

--- a/folio-test/infrastructure/keycloak_application.yaml
+++ b/folio-test/infrastructure/keycloak_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: keycloak
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/infrastructure/kong_application.yaml
+++ b/folio-test/infrastructure/kong_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: kong
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/infrastructure/kong_application.yaml
+++ b/folio-test/infrastructure/kong_application.yaml
@@ -11,7 +11,7 @@ spec:
     server: https://kubernetes.default.svc
   sources:
     - chart: kong
-      repoURL: oci://registry-1.docker.io/bitnamicharts/kong
+      repoURL: https://charts.bitnami.com/bitnami
       targetRevision: 12.0.11
       helm:
         valueFiles:

--- a/folio-test/infrastructure/postfix_application.yaml
+++ b/folio-test/infrastructure/postfix_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: mail
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/infrastructure/setae_application.yaml
+++ b/folio-test/infrastructure/setae_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: setae-api
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/stripes_application.yaml
+++ b/folio-test/infrastructure/stripes_application.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: folio-test
   sources:
     - repoURL: https://sul-dlss.github.io/folio-helm-v2
-      targetRevision: 2.24.0
+      targetRevision: 2.24.1
       helm:
         valueFiles:
           - $values/folio-test/infrastructure/stripes.yaml

--- a/folio-test/infrastructure/stripes_application.yaml
+++ b/folio-test/infrastructure/stripes_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: platform-complete
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/vault_application.yaml
+++ b/folio-test/infrastructure/vault_application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: vault
   namespace: folio-test
+  labels:
+    application: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/modules/mgr-applications/application.yaml
+++ b/folio-test/modules/mgr-applications/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: mgr-applications
   namespace: folio-test
+  labels:
+    application: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-test/modules/mgr-tenant-entitlements/application.yaml
+++ b/folio-test/modules/mgr-tenant-entitlements/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: mgr-tenant-entitlements
   namespace: folio-test
+  labels:
+    application: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-test/modules/mgr-tenants/application.yaml
+++ b/folio-test/modules/mgr-tenants/application.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: mgr-tenants
   namespace: folio-test
+  labels:
+    application: infrastructure
 operation:
   sync:
     syncStrategy:


### PR DESCRIPTION
Adds missing `application: infrastructure` labels for folio-test and bumps the platform-complete helm chart version to one with the extraDeploy key (for the HTTPRoutes).