### PR TITLE
Update labels

### DIFF
--- a/create_applications.py
+++ b/create_applications.py
@@ -24,7 +24,7 @@ args = parser.parse_args()
 if args.no_generate and args.execute == "dry-run":
     parser.error("--no_generate is set, but --execute is 'dry-run'. No applications will be generated or applied.")
 
-def application_manifest(name, version, namespace, application, repo_url, values_files):
+def application_manifest(name, version, namespace, application, module_type, repo_url, values_files):
     data = {
         "apiVersion": "argoproj.io/v1alpha1",
         "kind": "Application",
@@ -33,6 +33,7 @@ def application_manifest(name, version, namespace, application, repo_url, values
             "namespace": namespace,
             "labels": {
                 "application": application,
+                "type": module_type,
             }
         },
         "spec": {
@@ -64,6 +65,7 @@ def application_manifest(name, version, namespace, application, repo_url, values
 def create_applications(filename):
     with open(filename, "r") as file:
         data = json.load(file)
+        application = data["id"]
 
     modules = data["modules"]
     if args.modules:
@@ -71,7 +73,7 @@ def create_applications(filename):
 
     for module in modules:
         module_name = module["name"]
-        app_type = "module" if module_name.startswith("mod-") else "edge"
+        module_type = "module" if module_name.startswith("mod-") else "edge"
         dir = Path(f"{args.namespace}/modules/{module_name}")
         dir.mkdir(parents=True, exist_ok=True)
         values_files = []
@@ -118,7 +120,8 @@ def create_applications(filename):
                     name=module_name,
                     version=chart_version,
                     namespace=args.namespace,
-                    application=app_type,
+                    application=application,
+                    module_type=module_type,
                     repo_url=repo_url,
                     values_files=values_files
                 ))

--- a/folio-dev/infrastructure/elasticsearch_application.yaml
+++ b/folio-dev/infrastructure/elasticsearch_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-dev
   destination:

--- a/folio-dev/infrastructure/kafka_application.yaml
+++ b/folio-dev/infrastructure/kafka_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-folio-dev
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-dev
   destination:

--- a/folio-dev/infrastructure/keycloak_application.yaml
+++ b/folio-dev/infrastructure/keycloak_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keycloak
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-dev

--- a/folio-dev/infrastructure/kong_application.yaml
+++ b/folio-dev/infrastructure/kong_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kong
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-dev

--- a/folio-dev/infrastructure/postfix_application.yaml
+++ b/folio-dev/infrastructure/postfix_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mail
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-dev

--- a/folio-dev/infrastructure/stripes_application.yaml
+++ b/folio-dev/infrastructure/stripes_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: platform-complete
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-dev
   destination:

--- a/folio-dev/infrastructure/vault_application.yaml
+++ b/folio-dev/infrastructure/vault_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-dev

--- a/folio-dev/modules/edge-connexion/application.yaml
+++ b/folio-dev/modules/edge-connexion/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-connexion
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/edge-ncip/application.yaml
+++ b/folio-dev/modules/edge-ncip/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-ncip
   namespace: folio-dev
 spec:
@@ -21,7 +22,7 @@ spec:
       - $values/folio-dev/modules/edge-ncip/java_opts.yaml
       - $values/folio-dev/modules/edge-ncip/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
-    targetRevision: 1.10.0
+    targetRevision: 1.10.1
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
     targetRevision: main

--- a/folio-dev/modules/edge-sip2/application.yaml
+++ b/folio-dev/modules/edge-sip2/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-sip2
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mgr-applications/application.yaml
+++ b/folio-dev/modules/mgr-applications/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-applications
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-dev/modules/mgr-tenant-entitlements/application.yaml
+++ b/folio-dev/modules/mgr-tenant-entitlements/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-tenant-entitlements
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-dev/modules/mgr-tenants/application.yaml
+++ b/folio-dev/modules/mgr-tenants/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-tenants
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-dev/modules/mod-agreements/application.yaml
+++ b/folio-dev/modules/mod-agreements/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-agreements
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-audit/application.yaml
+++ b/folio-dev/modules/mod-audit/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-audit
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-batch-print/application.yaml
+++ b/folio-dev/modules/mod-batch-print/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-batch-print
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-bulk-operations/application.yaml
+++ b/folio-dev/modules/mod-bulk-operations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-bulk-edit-1.0.10
+    type: module
   name: mod-bulk-operations
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-calendar/application.yaml
+++ b/folio-dev/modules/mod-calendar/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-calendar
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-circulation-storage/application.yaml
+++ b/folio-dev/modules/mod-circulation-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-circulation-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-circulation/application.yaml
+++ b/folio-dev/modules/mod-circulation/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-circulation
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-configuration/application.yaml
+++ b/folio-dev/modules/mod-configuration/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-configuration
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-copycat/application.yaml
+++ b/folio-dev/modules/mod-copycat/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-copycat
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-courses/application.yaml
+++ b/folio-dev/modules/mod-courses/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-courses
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-data-export-spring/application.yaml
+++ b/folio-dev/modules/mod-data-export-spring/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export-spring
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-data-export-worker/application.yaml
+++ b/folio-dev/modules/mod-data-export-worker/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export-worker
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-data-export/application.yaml
+++ b/folio-dev/modules/mod-data-export/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-data-import/application.yaml
+++ b/folio-dev/modules/mod-data-import/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-import
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-di-converter-storage/application.yaml
+++ b/folio-dev/modules/mod-di-converter-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-di-converter-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-ebsconet/application.yaml
+++ b/folio-dev/modules/mod-ebsconet/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-ebsconet
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-email/application.yaml
+++ b/folio-dev/modules/mod-email/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-email
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-entities-links/application.yaml
+++ b/folio-dev/modules/mod-entities-links/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-entities-links
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-erm-usage-harvester/application.yaml
+++ b/folio-dev/modules/mod-erm-usage-harvester/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-erm-usage-harvester
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-erm-usage/application.yaml
+++ b/folio-dev/modules/mod-erm-usage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-erm-usage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-eusage-reports/application.yaml
+++ b/folio-dev/modules/mod-eusage-reports/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-eusage-reports
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-event-config/application.yaml
+++ b/folio-dev/modules/mod-event-config/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-event-config
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-feesfines/application.yaml
+++ b/folio-dev/modules/mod-feesfines/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-feesfines
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-finance-storage/application.yaml
+++ b/folio-dev/modules/mod-finance-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-finance-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-finance/application.yaml
+++ b/folio-dev/modules/mod-finance/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-finance
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-fqm-manager/application.yaml
+++ b/folio-dev/modules/mod-fqm-manager/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-fqm-1.0.15
+    type: module
   name: mod-fqm-manager
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-gobi/application.yaml
+++ b/folio-dev/modules/mod-gobi/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-gobi
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-graphql/application.yaml
+++ b/folio-dev/modules/mod-graphql/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-graphql
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-inventory-storage/application.yaml
+++ b/folio-dev/modules/mod-inventory-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-inventory-update/application.yaml
+++ b/folio-dev/modules/mod-inventory-update/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory-update
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-inventory/application.yaml
+++ b/folio-dev/modules/mod-inventory/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-invoice-storage/application.yaml
+++ b/folio-dev/modules/mod-invoice-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-invoice-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-invoice/application.yaml
+++ b/folio-dev/modules/mod-invoice/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-invoice
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-kb-ebsco-java/application.yaml
+++ b/folio-dev/modules/mod-kb-ebsco-java/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-kb-ebsco-java
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-licenses/application.yaml
+++ b/folio-dev/modules/mod-licenses/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-licenses
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-linked-data/application.yaml
+++ b/folio-dev/modules/mod-linked-data/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-linked-data-1.1.7
+    type: module
   name: mod-linked-data
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-lists/application.yaml
+++ b/folio-dev/modules/mod-lists/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-fqm-1.0.15
+    type: module
   name: mod-lists
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-login-keycloak/application.yaml
+++ b/folio-dev/modules/mod-login-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-login-keycloak
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-marc-migrations/application.yaml
+++ b/folio-dev/modules/mod-marc-migrations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-marc-migrations-2.0.5
+    type: module
   name: mod-marc-migrations
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-ncip/application.yaml
+++ b/folio-dev/modules/mod-ncip/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-ncip
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-notes/application.yaml
+++ b/folio-dev/modules/mod-notes/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-notes
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-notify/application.yaml
+++ b/folio-dev/modules/mod-notify/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-notify
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-okapi-facade/application.yaml
+++ b/folio-dev/modules/mod-okapi-facade/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-okapi-facade
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-orders-storage/application.yaml
+++ b/folio-dev/modules/mod-orders-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-orders-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-orders/application.yaml
+++ b/folio-dev/modules/mod-orders/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-orders
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-organizations-storage/application.yaml
+++ b/folio-dev/modules/mod-organizations-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-organizations-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-organizations/application.yaml
+++ b/folio-dev/modules/mod-organizations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-organizations
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-password-validator/application.yaml
+++ b/folio-dev/modules/mod-password-validator/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-password-validator
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-patron-blocks/application.yaml
+++ b/folio-dev/modules/mod-patron-blocks/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-patron-blocks
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-patron/application.yaml
+++ b/folio-dev/modules/mod-patron/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-patron
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-permissions/application.yaml
+++ b/folio-dev/modules/mod-permissions/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-permissions
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-pubsub/application.yaml
+++ b/folio-dev/modules/mod-pubsub/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-pubsub
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-quick-marc/application.yaml
+++ b/folio-dev/modules/mod-quick-marc/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-quick-marc
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-reading-room/application.yaml
+++ b/folio-dev/modules/mod-reading-room/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-reading-room-2.0.2
+    type: module
   name: mod-reading-room
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-record-specifications/application.yaml
+++ b/folio-dev/modules/mod-record-specifications/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-record-specifications
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-remote-storage/application.yaml
+++ b/folio-dev/modules/mod-remote-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-remote-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-roles-keycloak/application.yaml
+++ b/folio-dev/modules/mod-roles-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-roles-keycloak
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-rtac/application.yaml
+++ b/folio-dev/modules/mod-rtac/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-rtac
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-scheduler/application.yaml
+++ b/folio-dev/modules/mod-scheduler/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-scheduler
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-search/application.yaml
+++ b/folio-dev/modules/mod-search/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-search
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-sender/application.yaml
+++ b/folio-dev/modules/mod-sender/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-sender
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-serials-management/application.yaml
+++ b/folio-dev/modules/mod-serials-management/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-serials-management
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-service-interaction/application.yaml
+++ b/folio-dev/modules/mod-service-interaction/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-service-interaction
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-settings/application.yaml
+++ b/folio-dev/modules/mod-settings/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-settings
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-source-record-manager/application.yaml
+++ b/folio-dev/modules/mod-source-record-manager/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-source-record-manager
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-source-record-storage/application.yaml
+++ b/folio-dev/modules/mod-source-record-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-source-record-storage
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-tags/application.yaml
+++ b/folio-dev/modules/mod-tags/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-tags
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-template-engine/application.yaml
+++ b/folio-dev/modules/mod-template-engine/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-template-engine
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-user-import/application.yaml
+++ b/folio-dev/modules/mod-user-import/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-user-import
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-users-bl/application.yaml
+++ b/folio-dev/modules/mod-users-bl/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users-bl
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-users-keycloak/application.yaml
+++ b/folio-dev/modules/mod-users-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users-keycloak
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-users/application.yaml
+++ b/folio-dev/modules/mod-users/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users
   namespace: folio-dev
 spec:

--- a/folio-dev/modules/mod-z3950/application.yaml
+++ b/folio-dev/modules/mod-z3950/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-z3950-1.0.1
+    type: module
   name: mod-z3950
   namespace: folio-dev
 spec:
@@ -22,7 +23,7 @@ spec:
       - $values/folio-dev/common/java_opts.yaml
       - $values/folio-dev/modules/mod-z3950/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
-    targetRevision: 3.5.0
+    targetRevision: 3.5.1
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
     targetRevision: main

--- a/folio-dev/securitypolicy/application.yaml
+++ b/folio-dev/securitypolicy/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: folio-security-policy
   namespace: folio-dev
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-dev
   destination:

--- a/folio-stage/infrastructure/elasticsearch_application.yaml
+++ b/folio-stage/infrastructure/elasticsearch_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-stage
   destination:

--- a/folio-stage/infrastructure/kafka_application.yaml
+++ b/folio-stage/infrastructure/kafka_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-folio-stage
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-stage
   destination:

--- a/folio-stage/infrastructure/keycloak_application.yaml
+++ b/folio-stage/infrastructure/keycloak_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keycloak
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-stage

--- a/folio-stage/infrastructure/kong_application.yaml
+++ b/folio-stage/infrastructure/kong_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kong
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-stage

--- a/folio-stage/infrastructure/postfix_application.yaml
+++ b/folio-stage/infrastructure/postfix_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mail
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-stage

--- a/folio-stage/infrastructure/setae_application.yaml
+++ b/folio-stage/infrastructure/setae_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: setae-api
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-stage
   destination:

--- a/folio-stage/infrastructure/stripes_application.yaml
+++ b/folio-stage/infrastructure/stripes_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: platform-complete
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-stage
   destination:

--- a/folio-stage/infrastructure/vault_application.yaml
+++ b/folio-stage/infrastructure/vault_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-stage

--- a/folio-stage/modules/edge-connexion/application.yaml
+++ b/folio-stage/modules/edge-connexion/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-connexion
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/edge-ncip/application.yaml
+++ b/folio-stage/modules/edge-ncip/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-ncip
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/edge-sip2/application.yaml
+++ b/folio-stage/modules/edge-sip2/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-sip2
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mgr-applications/application.yaml
+++ b/folio-stage/modules/mgr-applications/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-applications
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-stage/modules/mgr-tenant-entitlements/application.yaml
+++ b/folio-stage/modules/mgr-tenant-entitlements/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-tenant-entitlements
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-stage/modules/mgr-tenants/application.yaml
+++ b/folio-stage/modules/mgr-tenants/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-tenants
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-stage/modules/mod-agreements/application.yaml
+++ b/folio-stage/modules/mod-agreements/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-agreements
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-audit/application.yaml
+++ b/folio-stage/modules/mod-audit/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-audit
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-batch-print/application.yaml
+++ b/folio-stage/modules/mod-batch-print/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-batch-print
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-bulk-operations/application.yaml
+++ b/folio-stage/modules/mod-bulk-operations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-bulk-edit-1.0.10
+    type: module
   name: mod-bulk-operations
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-calendar/application.yaml
+++ b/folio-stage/modules/mod-calendar/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-calendar
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-circulation-storage/application.yaml
+++ b/folio-stage/modules/mod-circulation-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-circulation-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-circulation/application.yaml
+++ b/folio-stage/modules/mod-circulation/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-circulation
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-configuration/application.yaml
+++ b/folio-stage/modules/mod-configuration/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-configuration
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-copycat/application.yaml
+++ b/folio-stage/modules/mod-copycat/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-copycat
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-courses/application.yaml
+++ b/folio-stage/modules/mod-courses/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-courses
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-data-export-spring/application.yaml
+++ b/folio-stage/modules/mod-data-export-spring/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export-spring
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-data-export-worker/application.yaml
+++ b/folio-stage/modules/mod-data-export-worker/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export-worker
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-data-export/application.yaml
+++ b/folio-stage/modules/mod-data-export/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-data-import/application.yaml
+++ b/folio-stage/modules/mod-data-import/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-import
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-di-converter-storage/application.yaml
+++ b/folio-stage/modules/mod-di-converter-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-di-converter-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-ebsconet/application.yaml
+++ b/folio-stage/modules/mod-ebsconet/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-ebsconet
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-email/application.yaml
+++ b/folio-stage/modules/mod-email/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-email
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-entities-links/application.yaml
+++ b/folio-stage/modules/mod-entities-links/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-entities-links
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-erm-usage-harvester/application.yaml
+++ b/folio-stage/modules/mod-erm-usage-harvester/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-erm-usage-harvester
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-erm-usage/application.yaml
+++ b/folio-stage/modules/mod-erm-usage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-erm-usage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-eusage-reports/application.yaml
+++ b/folio-stage/modules/mod-eusage-reports/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-eusage-reports
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-event-config/application.yaml
+++ b/folio-stage/modules/mod-event-config/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-event-config
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-feesfines/application.yaml
+++ b/folio-stage/modules/mod-feesfines/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-feesfines
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-finance-storage/application.yaml
+++ b/folio-stage/modules/mod-finance-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-finance-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-finance/application.yaml
+++ b/folio-stage/modules/mod-finance/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-finance
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-fqm-manager/application.yaml
+++ b/folio-stage/modules/mod-fqm-manager/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-fqm-1.0.15
+    type: module
   name: mod-fqm-manager
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-gobi/application.yaml
+++ b/folio-stage/modules/mod-gobi/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-gobi
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-graphql/application.yaml
+++ b/folio-stage/modules/mod-graphql/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-graphql
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-inventory-storage/application.yaml
+++ b/folio-stage/modules/mod-inventory-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-inventory-update/application.yaml
+++ b/folio-stage/modules/mod-inventory-update/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory-update
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-inventory/application.yaml
+++ b/folio-stage/modules/mod-inventory/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-invoice-storage/application.yaml
+++ b/folio-stage/modules/mod-invoice-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-invoice-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-invoice/application.yaml
+++ b/folio-stage/modules/mod-invoice/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-invoice
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-kb-ebsco-java/application.yaml
+++ b/folio-stage/modules/mod-kb-ebsco-java/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-kb-ebsco-java
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-licenses/application.yaml
+++ b/folio-stage/modules/mod-licenses/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-licenses
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-linked-data/application.yaml
+++ b/folio-stage/modules/mod-linked-data/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-linked-data-1.1.7
+    type: module
   name: mod-linked-data
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-lists/application.yaml
+++ b/folio-stage/modules/mod-lists/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-fqm-1.0.15
+    type: module
   name: mod-lists
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-login-keycloak/application.yaml
+++ b/folio-stage/modules/mod-login-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-login-keycloak
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-marc-migrations/application.yaml
+++ b/folio-stage/modules/mod-marc-migrations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-marc-migrations-2.0.5
+    type: module
   name: mod-marc-migrations
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-ncip/application.yaml
+++ b/folio-stage/modules/mod-ncip/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-ncip
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-notes/application.yaml
+++ b/folio-stage/modules/mod-notes/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-notes
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-notify/application.yaml
+++ b/folio-stage/modules/mod-notify/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-notify
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-okapi-facade/application.yaml
+++ b/folio-stage/modules/mod-okapi-facade/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-okapi-facade
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-orders-storage/application.yaml
+++ b/folio-stage/modules/mod-orders-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-orders-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-orders/application.yaml
+++ b/folio-stage/modules/mod-orders/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-orders
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-organizations-storage/application.yaml
+++ b/folio-stage/modules/mod-organizations-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-organizations-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-organizations/application.yaml
+++ b/folio-stage/modules/mod-organizations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-organizations
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-password-validator/application.yaml
+++ b/folio-stage/modules/mod-password-validator/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-password-validator
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-patron-blocks/application.yaml
+++ b/folio-stage/modules/mod-patron-blocks/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-patron-blocks
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-patron/application.yaml
+++ b/folio-stage/modules/mod-patron/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-patron
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-permissions/application.yaml
+++ b/folio-stage/modules/mod-permissions/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-permissions
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-pubsub/application.yaml
+++ b/folio-stage/modules/mod-pubsub/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-pubsub
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-quick-marc/application.yaml
+++ b/folio-stage/modules/mod-quick-marc/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-quick-marc
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-reading-room/application.yaml
+++ b/folio-stage/modules/mod-reading-room/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-reading-room-2.0.2
+    type: module
   name: mod-reading-room
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-record-specifications/application.yaml
+++ b/folio-stage/modules/mod-record-specifications/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-record-specifications
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-remote-storage/application.yaml
+++ b/folio-stage/modules/mod-remote-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-remote-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-roles-keycloak/application.yaml
+++ b/folio-stage/modules/mod-roles-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-roles-keycloak
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-rtac/application.yaml
+++ b/folio-stage/modules/mod-rtac/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-rtac
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-scheduler/application.yaml
+++ b/folio-stage/modules/mod-scheduler/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-scheduler
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-search/application.yaml
+++ b/folio-stage/modules/mod-search/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-search
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-sender/application.yaml
+++ b/folio-stage/modules/mod-sender/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-sender
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-serials-management/application.yaml
+++ b/folio-stage/modules/mod-serials-management/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-serials-management
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-service-interaction/application.yaml
+++ b/folio-stage/modules/mod-service-interaction/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-service-interaction
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-settings/application.yaml
+++ b/folio-stage/modules/mod-settings/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-settings
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-source-record-manager/application.yaml
+++ b/folio-stage/modules/mod-source-record-manager/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-source-record-manager
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-source-record-storage/application.yaml
+++ b/folio-stage/modules/mod-source-record-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-source-record-storage
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-tags/application.yaml
+++ b/folio-stage/modules/mod-tags/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-tags
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-template-engine/application.yaml
+++ b/folio-stage/modules/mod-template-engine/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-template-engine
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-user-import/application.yaml
+++ b/folio-stage/modules/mod-user-import/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-user-import
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-users-bl/application.yaml
+++ b/folio-stage/modules/mod-users-bl/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users-bl
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-users-keycloak/application.yaml
+++ b/folio-stage/modules/mod-users-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users-keycloak
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-users/application.yaml
+++ b/folio-stage/modules/mod-users/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users
   namespace: folio-stage
 spec:

--- a/folio-stage/modules/mod-z3950/application.yaml
+++ b/folio-stage/modules/mod-z3950/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-z3950-1.0.1
+    type: module
   name: mod-z3950
   namespace: folio-stage
 spec:

--- a/folio-stage/securitypolicy/application.yaml
+++ b/folio-stage/securitypolicy/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: folio-security-policy
   namespace: folio-stage
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-stage
   destination:

--- a/folio-test/infrastructure/elasticsearch_application.yaml
+++ b/folio-test/infrastructure/elasticsearch_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: elasticsearch
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/kafka_application.yaml
+++ b/folio-test/infrastructure/kafka_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kafka-folio-test
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/keycloak_application.yaml
+++ b/folio-test/infrastructure/keycloak_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: keycloak
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/infrastructure/kong_application.yaml
+++ b/folio-test/infrastructure/kong_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kong
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/infrastructure/postfix_application.yaml
+++ b/folio-test/infrastructure/postfix_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mail
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/infrastructure/setae_application.yaml
+++ b/folio-test/infrastructure/setae_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: setae-api
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/stripes_application.yaml
+++ b/folio-test/infrastructure/stripes_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: platform-complete
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-test
   destination:

--- a/folio-test/infrastructure/vault_application.yaml
+++ b/folio-test/infrastructure/vault_application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: vault
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   destination:
     namespace: folio-test

--- a/folio-test/modules/edge-connexion/application.yaml
+++ b/folio-test/modules/edge-connexion/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-connexion
   namespace: folio-test
 spec:

--- a/folio-test/modules/edge-ncip/application.yaml
+++ b/folio-test/modules/edge-ncip/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-ncip
   namespace: folio-test
 spec:
@@ -21,7 +22,7 @@ spec:
       - $values/folio-test/modules/edge-ncip/java_opts.yaml
       - $values/folio-test/modules/edge-ncip/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
-    targetRevision: 1.10.0
+    targetRevision: 1.10.1
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
     targetRevision: main

--- a/folio-test/modules/edge-sip2/application.yaml
+++ b/folio-test/modules/edge-sip2/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: edge
+    application: app-edge-complete-2.0.16
+    type: edge
   name: edge-sip2
   namespace: folio-test
 spec:

--- a/folio-test/modules/mgr-applications/application.yaml
+++ b/folio-test/modules/mgr-applications/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-applications
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-test/modules/mgr-tenant-entitlements/application.yaml
+++ b/folio-test/modules/mgr-tenant-entitlements/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-tenant-entitlements
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-test/modules/mgr-tenants/application.yaml
+++ b/folio-test/modules/mgr-tenants/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mgr-tenants
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 operation:
   sync:
     syncStrategy:

--- a/folio-test/modules/mod-agreements/application.yaml
+++ b/folio-test/modules/mod-agreements/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-agreements
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-audit/application.yaml
+++ b/folio-test/modules/mod-audit/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-audit
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-batch-print/application.yaml
+++ b/folio-test/modules/mod-batch-print/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-batch-print
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-bulk-operations/application.yaml
+++ b/folio-test/modules/mod-bulk-operations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-bulk-edit-1.0.10
+    type: module
   name: mod-bulk-operations
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-calendar/application.yaml
+++ b/folio-test/modules/mod-calendar/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-calendar
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-circulation-storage/application.yaml
+++ b/folio-test/modules/mod-circulation-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-circulation-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-circulation/application.yaml
+++ b/folio-test/modules/mod-circulation/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-circulation
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-configuration/application.yaml
+++ b/folio-test/modules/mod-configuration/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-configuration
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-copycat/application.yaml
+++ b/folio-test/modules/mod-copycat/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-copycat
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-courses/application.yaml
+++ b/folio-test/modules/mod-courses/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-courses
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-data-export-spring/application.yaml
+++ b/folio-test/modules/mod-data-export-spring/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export-spring
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-data-export-worker/application.yaml
+++ b/folio-test/modules/mod-data-export-worker/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export-worker
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-data-export/application.yaml
+++ b/folio-test/modules/mod-data-export/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-export
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-data-import/application.yaml
+++ b/folio-test/modules/mod-data-import/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-data-import
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-di-converter-storage/application.yaml
+++ b/folio-test/modules/mod-di-converter-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-di-converter-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-ebsconet/application.yaml
+++ b/folio-test/modules/mod-ebsconet/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-ebsconet
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-email/application.yaml
+++ b/folio-test/modules/mod-email/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-email
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-entities-links/application.yaml
+++ b/folio-test/modules/mod-entities-links/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-entities-links
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-erm-usage-harvester/application.yaml
+++ b/folio-test/modules/mod-erm-usage-harvester/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-erm-usage-harvester
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-erm-usage/application.yaml
+++ b/folio-test/modules/mod-erm-usage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-erm-usage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-eusage-reports/application.yaml
+++ b/folio-test/modules/mod-eusage-reports/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-erm-usage-2.0.5
+    type: module
   name: mod-eusage-reports
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-event-config/application.yaml
+++ b/folio-test/modules/mod-event-config/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-event-config
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-feesfines/application.yaml
+++ b/folio-test/modules/mod-feesfines/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-feesfines
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-finance-storage/application.yaml
+++ b/folio-test/modules/mod-finance-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-finance-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-finance/application.yaml
+++ b/folio-test/modules/mod-finance/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-finance
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-fqm-manager/application.yaml
+++ b/folio-test/modules/mod-fqm-manager/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-fqm-1.0.15
+    type: module
   name: mod-fqm-manager
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-gobi/application.yaml
+++ b/folio-test/modules/mod-gobi/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-gobi
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-graphql/application.yaml
+++ b/folio-test/modules/mod-graphql/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-graphql
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-inventory-storage/application.yaml
+++ b/folio-test/modules/mod-inventory-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-inventory-update/application.yaml
+++ b/folio-test/modules/mod-inventory-update/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory-update
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-inventory/application.yaml
+++ b/folio-test/modules/mod-inventory/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-inventory
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-invoice-storage/application.yaml
+++ b/folio-test/modules/mod-invoice-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-invoice-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-invoice/application.yaml
+++ b/folio-test/modules/mod-invoice/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-invoice
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-kb-ebsco-java/application.yaml
+++ b/folio-test/modules/mod-kb-ebsco-java/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-kb-ebsco-java
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-licenses/application.yaml
+++ b/folio-test/modules/mod-licenses/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-licenses
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-linked-data/application.yaml
+++ b/folio-test/modules/mod-linked-data/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-linked-data-1.1.7
+    type: module
   name: mod-linked-data
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-lists/application.yaml
+++ b/folio-test/modules/mod-lists/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-fqm-1.0.15
+    type: module
   name: mod-lists
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-login-keycloak/application.yaml
+++ b/folio-test/modules/mod-login-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-login-keycloak
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-marc-migrations/application.yaml
+++ b/folio-test/modules/mod-marc-migrations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-marc-migrations-2.0.5
+    type: module
   name: mod-marc-migrations
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-ncip/application.yaml
+++ b/folio-test/modules/mod-ncip/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-ncip
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-notes/application.yaml
+++ b/folio-test/modules/mod-notes/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-notes
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-notify/application.yaml
+++ b/folio-test/modules/mod-notify/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-notify
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-okapi-facade/application.yaml
+++ b/folio-test/modules/mod-okapi-facade/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-okapi-facade
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-orders-storage/application.yaml
+++ b/folio-test/modules/mod-orders-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-orders-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-orders/application.yaml
+++ b/folio-test/modules/mod-orders/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-orders
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-organizations-storage/application.yaml
+++ b/folio-test/modules/mod-organizations-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-organizations-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-organizations/application.yaml
+++ b/folio-test/modules/mod-organizations/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-acquisitions-1.0.29
+    type: module
   name: mod-organizations
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-password-validator/application.yaml
+++ b/folio-test/modules/mod-password-validator/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-password-validator
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-patron-blocks/application.yaml
+++ b/folio-test/modules/mod-patron-blocks/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-patron-blocks
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-patron/application.yaml
+++ b/folio-test/modules/mod-patron/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-patron
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-permissions/application.yaml
+++ b/folio-test/modules/mod-permissions/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-permissions
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-pubsub/application.yaml
+++ b/folio-test/modules/mod-pubsub/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-pubsub
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-quick-marc/application.yaml
+++ b/folio-test/modules/mod-quick-marc/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-quick-marc
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-reading-room/application.yaml
+++ b/folio-test/modules/mod-reading-room/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-reading-room-2.0.2
+    type: module
   name: mod-reading-room
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-record-specifications/application.yaml
+++ b/folio-test/modules/mod-record-specifications/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-record-specifications
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-remote-storage/application.yaml
+++ b/folio-test/modules/mod-remote-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-remote-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-roles-keycloak/application.yaml
+++ b/folio-test/modules/mod-roles-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-roles-keycloak
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-rtac/application.yaml
+++ b/folio-test/modules/mod-rtac/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-rtac
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-scheduler/application.yaml
+++ b/folio-test/modules/mod-scheduler/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-scheduler
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-search/application.yaml
+++ b/folio-test/modules/mod-search/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-search
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-sender/application.yaml
+++ b/folio-test/modules/mod-sender/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-sender
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-serials-management/application.yaml
+++ b/folio-test/modules/mod-serials-management/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-serials-management
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-service-interaction/application.yaml
+++ b/folio-test/modules/mod-service-interaction/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-service-interaction
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-settings/application.yaml
+++ b/folio-test/modules/mod-settings/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-settings
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-source-record-manager/application.yaml
+++ b/folio-test/modules/mod-source-record-manager/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-source-record-manager
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-source-record-storage/application.yaml
+++ b/folio-test/modules/mod-source-record-storage/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-source-record-storage
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-tags/application.yaml
+++ b/folio-test/modules/mod-tags/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-tags
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-template-engine/application.yaml
+++ b/folio-test/modules/mod-template-engine/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-template-engine
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-user-import/application.yaml
+++ b/folio-test/modules/mod-user-import/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-complete-2.5.10
+    type: module
   name: mod-user-import
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-users-bl/application.yaml
+++ b/folio-test/modules/mod-users-bl/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users-bl
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-users-keycloak/application.yaml
+++ b/folio-test/modules/mod-users-keycloak/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users-keycloak
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-users/application.yaml
+++ b/folio-test/modules/mod-users/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-platform-minimal-2.0.52
+    type: module
   name: mod-users
   namespace: folio-test
 spec:

--- a/folio-test/modules/mod-z3950/application.yaml
+++ b/folio-test/modules/mod-z3950/application.yaml
@@ -2,7 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   labels:
-    application: module
+    application: app-z3950-1.0.1
+    type: module
   name: mod-z3950
   namespace: folio-test
 spec:
@@ -23,7 +24,7 @@ spec:
       - $values/folio-test/common/java_opts.yaml
       - $values/folio-test/modules/mod-z3950/extra_env.yaml
     repoURL: https://sul-dlss.github.io/folio-helm-v2
-    targetRevision: 3.5.0
+    targetRevision: 3.5.1
   - ref: values
     repoURL: https://github.com/sul-dlss/folio-eureka
     targetRevision: main

--- a/folio-test/securitypolicy/application.yaml
+++ b/folio-test/securitypolicy/application.yaml
@@ -4,7 +4,7 @@ metadata:
   name: folio-security-policy
   namespace: folio-test
   labels:
-    application: infrastructure
+    type: infrastructure
 spec:
   project: folio-test
   destination:


### PR DESCRIPTION
This changes the label "application" to "type" (for infrastructure, edge, module) and uses the application ID as the application label. It might be useful to filter and select ArgoCD applications based on the app, i.e. app-platform-minimal-2.0.52.